### PR TITLE
Fix docker permissions

### DIFF
--- a/.docker/rootfs/etc/fix-attrs.d/01-tasmoadmin
+++ b/.docker/rootfs/etc/fix-attrs.d/01-tasmoadmin
@@ -1,1 +1,1 @@
-/var/www/tasmoadmin true nginx 0644 0755
+/var/www/tasmoadmin/tmp true nginx 0644 0755


### PR DESCRIPTION
I noticed when using the docker-compose stack the files were being owned by random UID making development really difficult.

This change makes s6 setup only ensure that the permissions are correctly set on the `tmp` dir which is where sessions and other "generated" files are created.

Not sure on the wider implication of this change? but it should be not an issue?