### PR TITLE
Improve developer flow

### DIFF
--- a/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
+++ b/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
@@ -51,9 +51,11 @@ if [ ! -d "/data/tasmoadmin/updates" ]; then
     echo "/data/tasmoadmin/updates created."
 fi
 
-echo 'Symlinking /data/tasmoadmin directory to persistent storage location...'
-rm -f -r /var/www/tasmoadmin/data
-ln -s /data/tasmoadmin /var/www/tasmoadmin/data
+if [[ -z "${TASMOADMIN_DATADIR}" ]]; then
+  echo 'Symlinking /data/tasmoadmin directory to persistent storage location...'
+  rm -f -r /var/www/tasmoadmin/data
+  ln -s /data/tasmoadmin /var/www/tasmoadmin/data
+fi
 
 # Ensure file permissions
 chown -R nginx:nginx /data/tasmoadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: .docker/Dockerfile.alpine-tmpl
     ports:
       - "8000:80"
+    environment:
+      - TASMOADMIN_DATADIR=/data/tasmoadmin/
     volumes:
       - ./tasmoadmin:/var/www/tasmoadmin
       - ./.storage:/data/tasmoadmin

--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -41,7 +41,7 @@ define( "_HELPERSDIR_", _APPROOT_."helpers/" );
 define( "_RESOURCESDIR_", _APPROOT_."resources/" );
 define( "_LIBSDIR_", _APPROOT_."libs/" );
 define( "_PAGESDIR_", _APPROOT_."pages/" );
-define( "_DATADIR_", getenv('TASMOADMIN_DATADIR') ?? _APPROOT_."data/" );
+define( "_DATADIR_", getenv('TASMOADMIN_DATADIR') ?: _APPROOT_."data/" );
 define( "_LANGDIR_", _APPROOT_."lang/" );
 define( "_CSVFILE_", _DATADIR_."devices.csv" );
 

--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -41,7 +41,7 @@ define( "_HELPERSDIR_", _APPROOT_."helpers/" );
 define( "_RESOURCESDIR_", _APPROOT_."resources/" );
 define( "_LIBSDIR_", _APPROOT_."libs/" );
 define( "_PAGESDIR_", _APPROOT_."pages/" );
-define( "_DATADIR_", _APPROOT_."data/" );
+define( "_DATADIR_", getenv('TASMOADMIN_DATADIR') ?? _APPROOT_."data/" );
 define( "_LANGDIR_", _APPROOT_."lang/" );
 define( "_CSVFILE_", _DATADIR_."devices.csv" );
 


### PR DESCRIPTION
Right now the situation is that when the development environment starts up we have deleted files in the data directory.

With this change we allow the override of this data directory with the envvar `TASMOADMIN_DATADIR` while falling back to the current behaviour if this is not set.