### PR TITLE
Fix JSON language dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@
 
 /tasmoadmin/vendor/
 /tasmoadmin/composer.lock
-/tasmoadmin/.phpunit.result.cache
+.phpunit.result.cache
 
 
 !.empty

--- a/tasmoadmin/composer.json
+++ b/tasmoadmin/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL3",
     "require": {
         "php": ">=7.4",
+        "ext-json": "*",
         "erusev/parsedown": "^1.7",
         "philipp15b/php-i18n": "^4.0"
     },

--- a/tasmoadmin/composer.json
+++ b/tasmoadmin/composer.json
@@ -14,7 +14,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3.8"
+        "phpunit/phpunit": "^9.3.8",
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -103,6 +103,7 @@ if( file_exists( _APPROOT_.".dockerenv" ) ) {
 require_once _APPROOT_ . 'vendor/autoload.php';
 
 use TasmoAdmin\Config;
+use TasmoAdmin\Helper\JsonLanguageHelper;
 use TasmoAdmin\Sonoff;
 
 $Config = new Config();
@@ -123,12 +124,14 @@ $i18n->setCachePath( _TMPDIR_.'cache/i18n/' );
 $i18n->setFilePath( _LANGDIR_.'lang_{LANGUAGE}.ini' ); // language file path
 $i18n->setFallbackLang( 'en' );
 $i18n->setPrefix( '__L' );
-$i18n->setSectionSeperator( '_' );
-$i18n->setMergeFallback( TRUE ); // make keys available from the fallback language
+$i18n->setSectionSeparator( '_' );
+$i18n->setMergeFallback( true ); // make keys available from the fallback language
 $i18n->init();
 
 $lang = $i18n->getAppliedLang();
 
+$langHelper = new JsonLanguageHelper($lang, _LANGDIR_."lang_${lang}.ini", _TMPDIR_.'cache/i18n/');
+$langHelper->dumpJson();
 
 if( ( isset ( $_SESSION[ "login" ] ) && $_SESSION[ "login" ] == "1" ) || $Config->read( "login" ) == "0" ) {
     $loggedin = TRUE;

--- a/tasmoadmin/src/Helper/JsonLanguageHelper.php
+++ b/tasmoadmin/src/Helper/JsonLanguageHelper.php
@@ -20,28 +20,30 @@ class JsonLanguageHelper
     }
 
     /**
-     * @return void
      * @throws JsonException
      */
     public function dumpJson(): void
     {
-        if ($this->hasExistingFile() && $this->isCacheModifiedNewerThenLanguageFile()) {
+        $cacheFile = $this->cacheFile();
+
+        if ($this->hasExistingFile($cacheFile) && $this->isCacheModifiedNewerThenLanguageFile($cacheFile)) {
             return;
         }
 
-        $this->writeFile();
+        $this->writeFile($cacheFile);
     }
 
     /**
+     * @param string $cacheFile
      * @return void
      * @throws JsonException
      */
-    private function writeFile(): void
+    private function writeFile(string $cacheFile): void
     {
         $config = parse_ini_file($this->languageFile);
         $jsConfig = $this->removeBlocks($config);
         $jsonCompiled = json_encode([$this->language => $jsConfig], JSON_THROW_ON_ERROR);
-        file_put_contents($this->cacheFile(), $jsonCompiled);
+        file_put_contents($cacheFile, $jsonCompiled);
     }
 
     private function removeBlocks($config): array
@@ -60,9 +62,9 @@ class JsonLanguageHelper
         return $jsConfig;
     }
 
-    private function hasExistingFile(): bool
+    private function hasExistingFile(string $cacheFile): bool
     {
-        return file_exists($this->cacheFile());
+        return file_exists($cacheFile);
     }
 
     private function cacheFile(): string
@@ -70,8 +72,8 @@ class JsonLanguageHelper
         return sprintf('%s/json_i18n_%s.cache.json', $this->cacheDir, $this->language);
     }
 
-    private function isCacheModifiedNewerThenLanguageFile(): bool
+    private function isCacheModifiedNewerThenLanguageFile(string $cacheFile): bool
     {
-        return filemtime($this->cacheFile()) > filemtime($this->languageFile);
+        return filemtime($cacheFile) > filemtime($this->languageFile);
     }
 }

--- a/tasmoadmin/src/Helper/JsonLanguageHelper.php
+++ b/tasmoadmin/src/Helper/JsonLanguageHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace TasmoAdmin\Helper;
+
+use JsonException;
+
+class JsonLanguageHelper
+{
+    private string $language;
+
+    private string $languageFile;
+
+    private string $cacheDir;
+
+    public function __construct(string $language, string $languageFile, string $cacheDir)
+    {
+        $this->language = $language;
+        $this->languageFile = $languageFile;
+        $this->cacheDir = $cacheDir;
+    }
+
+    /**
+     * @return void
+     * @throws JsonException
+     */
+    public function dumpJson(): void
+    {
+        if ($this->hasExistingFile() && $this->isCacheModifiedNewerThenLanguageFile()) {
+            return;
+        }
+
+        $this->writeFile();
+    }
+
+    /**
+     * @return void
+     * @throws JsonException
+     */
+    private function writeFile(): void
+    {
+        $config = parse_ini_file($this->languageFile);
+        $jsConfig = $this->removeBlocks($config);
+        $jsonCompiled = json_encode([$this->language => $jsConfig], JSON_THROW_ON_ERROR);
+        file_put_contents($this->cacheFile(), $jsonCompiled);
+    }
+
+    private function removeBlocks($config): array
+    {
+        $jsConfig = [];
+        foreach ($config as $key => $value) {
+            if (is_array($value)) {
+                foreach ($value as $blockKey => $blockValue) {
+                    $jsConfig[$blockKey] = $blockValue;
+                }
+            } else {
+                $jsConfig[$key] = $value;
+            }
+        }
+
+        return $jsConfig;
+    }
+
+    private function hasExistingFile(): bool
+    {
+        return file_exists($this->cacheFile());
+    }
+
+    private function cacheFile(): string
+    {
+        return sprintf('%s/json_i18n_%s.cache.json', $this->cacheDir, $this->language);
+    }
+
+    private function isCacheModifiedNewerThenLanguageFile(): bool
+    {
+        return filemtime($this->cacheFile()) > filemtime($this->languageFile);
+    }
+}

--- a/tasmoadmin/tests/Helper/JsonLanguageHelperTest.php
+++ b/tasmoadmin/tests/Helper/JsonLanguageHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\TasmoAdmin\Helper;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use TasmoAdmin\Helper\JsonLanguageHelper;
+use PHPUnit\Framework\TestCase;
+
+class JsonLanguageHelperTest extends TestCase
+{
+    private vfsStreamDirectory $root;
+
+    public function setUp(): void
+    {
+        $this->root = vfsStream::setup();
+    }
+
+    public function testDumpJson()
+    {
+        $jsonLanguageHelper = new JsonLanguageHelper(
+            'en',
+            FIXTURE_PATH . 'language_en.ini',
+            $this->root->url()
+        );
+
+        $jsonLanguageHelper->dumpJson();
+        self::assertTrue($this->root->hasChild('json_i18n_en.cache.json'));
+        self::assertEquals(['en' => [
+            'HELLO' => 'hello',
+            'WORLD' => 'world',
+        ]], json_decode($this->root->getChild('json_i18n_en.cache.json')->getContent(), true));
+    }
+}

--- a/tasmoadmin/tests/bootstrap.php
+++ b/tasmoadmin/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
-require_once __DIR__ . "/../vendor/autoload.php"; 
+require_once __DIR__ . "/../vendor/autoload.php";
 
-define( "_DATADIR_", "" );
+const _DATADIR_ = "";
+
+const FIXTURE_PATH = __DIR__ . '/fixtures/';

--- a/tasmoadmin/tests/fixtures/language_en.ini
+++ b/tasmoadmin/tests/fixtures/language_en.ini
@@ -1,0 +1,4 @@
+HELLO="hello"
+
+[WORLD]
+WORLD="world"


### PR DESCRIPTION
When migrating to composer I wasnt aware of the modifications to the language helper resulting in the JSON dumping being broken. This change introduces the language dumping support. 