### PR TITLE
Fix dev docker push

### DIFF
--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -98,7 +98,6 @@ docker_manifest_list() {
 
     if [[ ${BUILD_VERSION} == "dev" ]]; then
         echo "DOCKER MANIFEST: Create and Push docker manifest lists DEV."
-        docker_manifest_list_dev
     elif [[ ${BUILD_VERSION} == *"beta"* ]]; then
         echo "DOCKER MANIFEST: Create and Push docker manifest lists BETA."
         docker_manifest_list_beta
@@ -140,22 +139,6 @@ docker_manifest_list_latest() {
 
   # Manifest Push BUILD_VERSION
   docker manifest push $TARGET:latest
-}
-
-docker_manifest_list_dev() {
-  # Manifest Create dev
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - $TARGET:dev."
-  docker manifest create $TARGET:dev \
-      $TARGET:$BUILD_VERSION-alpine-amd64 \
-      $TARGET:$BUILD_VERSION-alpine-arm32v6 \
-      $TARGET:$BUILD_VERSION-alpine-arm64v8
-
-  # Manifest Annotate BUILD_VERSION
-  docker manifest annotate $TARGET:dev $TARGET:$BUILD_VERSION-alpine-arm32v6 --os=linux --arch=arm --variant=v6
-  docker manifest annotate $TARGET:dev $TARGET:$BUILD_VERSION-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
-
-  # Manifest Push BUILD_VERSION
-  docker manifest push $TARGET:dev
 }
 
 docker_manifest_list_beta() {


### PR DESCRIPTION
It's already pushed as `dev` since we set the `BUILD_VERSION` so we don't need to unify anything.