### PR TITLE
Fix local dev for firmware path

### DIFF
--- a/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
+++ b/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
@@ -55,6 +55,7 @@ if [[ -z "${TASMO_DATADIR}" ]]; then
   echo 'Symlinking /data/tasmoadmin directory to persistent storage location...'
   rm -f -r /var/www/tasmoadmin/data
   ln -s /data/tasmoadmin /var/www/tasmoadmin/data
+  sed -i '/alias \/data\/tasmoadmin\/firmwares\/;/d' /etc/nginx/nginx.conf
 fi
 
 # Ensure file permissions

--- a/.docker/rootfs/etc/nginx/nginx-ssl.conf
+++ b/.docker/rootfs/etc/nginx/nginx-ssl.conf
@@ -55,6 +55,7 @@ http {
         fastcgi_buffers 16 512k;
 
         location /data/firmwares {
+            alias /data/tasmoadmin/firmwares/;
             add_header Access-Control-Allow-Origin *;
         }
 

--- a/.docker/rootfs/etc/nginx/nginx.conf
+++ b/.docker/rootfs/etc/nginx/nginx.conf
@@ -54,6 +54,7 @@ http {
         }
 
         location /data/tasmoadmin/ {
+            alias /data/tasmoadmin/firmwares/;
             deny all;
         }
 


### PR DESCRIPTION
Previously was unable to access mounted `.storage` firmware folder. With this change if `TASMO_DATADIR` not set remove the alias that fixes it.
 