### PR TITLE
Use env var instead of hardcoding for local-dev

### DIFF
--- a/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
+++ b/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
@@ -55,7 +55,8 @@ if [[ -z "${TASMO_DATADIR}" ]]; then
   echo 'Symlinking /data/tasmoadmin directory to persistent storage location...'
   rm -f -r /var/www/tasmoadmin/data
   ln -s /data/tasmoadmin /var/www/tasmoadmin/data
-  sed -i '/alias \/data\/tasmoadmin\/firmwares\/;/d' /etc/nginx/nginx.conf
+else
+    sed -i 's@location /data/firmwares {@location /data/firmwares {\n            alias '"$TASMO_DATADIR"';@'  /etc/nginx/nginx.conf
 fi
 
 # Ensure file permissions

--- a/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
+++ b/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
@@ -56,7 +56,7 @@ if [[ -z "${TASMO_DATADIR}" ]]; then
   rm -f -r /var/www/tasmoadmin/data
   ln -s /data/tasmoadmin /var/www/tasmoadmin/data
 else
-    sed -i 's@location /data/firmwares {@location /data/firmwares {\n            alias '"$TASMO_DATADIR"';@'  /etc/nginx/nginx.conf
+    sed -i 's@location /data/firmwares {@location /data/firmwares {\n            alias '"$TASMO_DATADIR"';@' /etc/nginx/nginx.conf
 fi
 
 # Ensure file permissions

--- a/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
+++ b/.docker/rootfs/etc/cont-init.d/16-persistent-data-tasmoadmin.sh
@@ -56,7 +56,7 @@ if [[ -z "${TASMO_DATADIR}" ]]; then
   rm -f -r /var/www/tasmoadmin/data
   ln -s /data/tasmoadmin /var/www/tasmoadmin/data
 else
-    sed -i 's@location /data/firmwares {@location /data/firmwares {\n            alias '"$TASMO_DATADIR"';@' /etc/nginx/nginx.conf
+    sed -i 's@location /data/firmwares {@location /data/firmwares {\n            alias '"$TASMO_DATADIR"'firmwares/;@' /etc/nginx/nginx.conf
 fi
 
 # Ensure file permissions

--- a/.docker/rootfs/etc/nginx/nginx-ssl.conf
+++ b/.docker/rootfs/etc/nginx/nginx-ssl.conf
@@ -55,7 +55,6 @@ http {
         fastcgi_buffers 16 512k;
 
         location /data/firmwares {
-            alias /data/tasmoadmin/firmwares/;
             add_header Access-Control-Allow-Origin *;
         }
 

--- a/.docker/rootfs/etc/nginx/nginx.conf
+++ b/.docker/rootfs/etc/nginx/nginx.conf
@@ -50,7 +50,6 @@ http {
 
 
         location /data/firmwares {
-            alias /data/tasmoadmin/firmwares/;
             add_header Access-Control-Allow-Origin *;
         }
 

--- a/.docker/rootfs/etc/nginx/nginx.conf
+++ b/.docker/rootfs/etc/nginx/nginx.conf
@@ -54,7 +54,6 @@ http {
         }
 
         location /data/tasmoadmin/ {
-            alias /data/tasmoadmin/firmwares/;
             deny all;
         }
 


### PR DESCRIPTION
Inject alias for local dev when `TASMO_DATADIR` env var set.