### PR TITLE
Fix IP range logic

### DIFF
--- a/tasmoadmin/src/Helper/IpHelper.php
+++ b/tasmoadmin/src/Helper/IpHelper.php
@@ -6,37 +6,33 @@ use InvalidArgumentException;
 
 class IpHelper
 {
+    public const MAX_IPS = 1024;
+
     public function fetchIps(string $fromIp, string $toIp, array $excludedIps = []): array
     {
-        $fromIpArray = explode('.', $fromIp);
-        $toIpArray = explode('.', $toIp);
-        if (!$this->isIpValid($fromIpArray)) {
+        if (!$this->isIpValid($fromIp)) {
             throw new InvalidArgumentException(sprintf('%s is an invalid IPv4 address', $fromIp));
         }
-        if (!$this->isIpValid($toIpArray)) {
+        if (!$this->isIpValid($toIp)) {
             throw new InvalidArgumentException(sprintf('%s is an invalid IPv4 address', $toIp));
         }
 
-        $ips = [];
 
-        while ($fromIpArray[2] <= $toIpArray[2]) {
-            while ($fromIpArray[3] <= $toIpArray[3]) {
-                if (!in_array(implode(".", $fromIpArray), $excludedIps, true)) {
-                    $ips[] = implode(".", $fromIpArray);
-                }
+        $ips = array_map('long2ip', range(ip2long($fromIp), ip2long($toIp)));
 
-                $fromIpArray[3]++;
-            }
-            $fromIpArray[3] = 0;
-            $fromIpArray[2]++;
+
+        $ips = array_diff($ips, $excludedIps);
+
+        if (count($ips) > self::MAX_IPS) {
+            throw new InvalidArgumentException('The defined IP range is too large, please specify a smaller range');
         }
 
         return $ips;
     }
 
 
-    private function isIpValid(array $ipArray): bool
+    private function isIpValid(string $ip): bool
     {
-        return count($ipArray) === 4 && filter_var(implode(".", $ipArray), FILTER_VALIDATE_IP);
+        return ip2long($ip) !== false;
     }
 }

--- a/tasmoadmin/tests/Helper/IpHelperTest.php
+++ b/tasmoadmin/tests/Helper/IpHelperTest.php
@@ -19,11 +19,18 @@ class IpHelperTest extends TestCase
     public function testFetchIpsMultipleSubnet(): void
     {
         $ipHelper = new IpHelper();
-        $ips = $ipHelper->fetchIps('127.0.0.1', '127.0.1.254');
+        $ips = $ipHelper->fetchIps('127.0.0.128', '127.0.1.2');
 
-        self::assertCount(509, $ips);
-        self::assertEquals('127.0.0.1',$ips[0]);
-        self::assertEquals('127.0.1.254',end($ips));
+        self::assertCount(131, $ips);
+        self::assertEquals('127.0.0.128',$ips[0]);
+        self::assertEquals('127.0.1.2',end($ips));
+    }
+
+    public function testFetchIpsTooLargeRange(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $ipHelper = new IpHelper();
+        $ipHelper->fetchIps('127.0.0.1', '127.0.8.2');
     }
 
     public function testFetchIpsSingleIp(): void


### PR DESCRIPTION
Limit the max amount of IPs to be scanned to 1024 whilst also fixing the IP range logic by leveraging PHP's built in functionality.

![image](https://user-images.githubusercontent.com/713525/194164732-4b31d0be-ced9-4cf8-8fec-27d1ece2b23f.png)



Resolves #667 
