### PR TITLE
Handle device IDs better

### DIFF
--- a/tasmoadmin/src/DeviceRepository.php
+++ b/tasmoadmin/src/DeviceRepository.php
@@ -43,10 +43,10 @@ class DeviceRepository
     public function addDevices(array $devices, string $deviceUsername, string $devicePassword): void
     {
         $handle = fopen($this->file, "a");
+        $nextId = $this->getNextId();
         foreach ($devices as $device) {
-            $fp = file($this->file);
             $deviceHolder = [];
-            $deviceHolder[0] = count($fp) + 1;
+            $deviceHolder[0] = $nextId++;
             $deviceHolder[1] = implode("|", $device["device_name"] ?? []);
             $deviceHolder[2] = $device["device_ip"] ?? "";
             $deviceHolder[3] = $deviceUsername;
@@ -194,5 +194,15 @@ class DeviceRepository
     private function createDeviceObject(array $deviceLine): ?Device
     {
         return DeviceFactory::fromArray($deviceLine);
+    }
+
+    private function getNextId(): int
+    {
+        $id = 0;
+        foreach ($this->getDevices() as $device) {
+            $id = max($id, $device->id);
+        }
+
+        return $id + 1;
     }
 }

--- a/tasmoadmin/tests/DeviceRepositoryTest.php
+++ b/tasmoadmin/tests/DeviceRepositoryTest.php
@@ -33,6 +33,40 @@ class DeviceRepositoryTest extends TestCase
         self::assertEquals(['socket-1'], $device->names);
     }
 
+    public function testAddDeviceId(): void
+    {
+        $repo = $this->getVirtualRepo();
+
+        $repo->addDevice([
+            'device_name' => ['socket-1'],
+            'device_ip' => '127.0.0.1',
+            'device_img' => 'orange',
+            'device_position' => 1,
+        ]);
+        $repo->addDevice([
+            'device_name' => ['socket-2'],
+            'device_ip' => '127.0.0.1',
+            'device_img' => 'orange',
+            'device_position' => 2,
+        ]);
+        self::assertCount(2, $repo->getDevices());
+        $repo->removeDevice(1);
+        self::assertCount(1, $repo->getDevices());
+        $repo->addDevice([
+            'device_name' => ['socket-3'],
+            'device_ip' => '127.0.0.1',
+            'device_img' => 'orange',
+            'device_position' => 2,
+        ]);
+        $device1 = $repo->getDevices()[0];
+        self::assertEquals(['socket-2'], $device1->names);
+        self::assertEquals(2, $device1->id);
+        $device2 = $repo->getDevices()[1];
+        self::assertEquals(['socket-3'], $device2->names);
+        self::assertEquals(3, $device2->id);
+    }
+
+
     public function testAddDevicesEmptyDevices(): void
     {
         $repo = $this->getVirtualRepo();


### PR DESCRIPTION
Helps with #713

Previously it was setting the ID of new devices to the number of lines +1 which would cause issues when IDs were removed before hand.

With this change we take the largest Id and +1 to it to ensure more uniqueness.