### PR TITLE
Add PHP 8.2. to matrix test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ['8.1', '8.0', '7.4']
+        php-version: ['8.2', '8.1', '8.0', '7.4']
     steps:
     - uses: actions/checkout@v3
     - name: Install PHP


### PR DESCRIPTION
Since PHP 8.2 is now available we should support it.