### PR TITLE
Allow automatic HTTP Basic authentication on device list pages

### DIFF
--- a/tasmoadmin/pages/devices_details.php
+++ b/tasmoadmin/pages/devices_details.php
@@ -61,7 +61,7 @@ if( $container->get(ViewHelper::class)->getNightMode(date('H')) === "nightmode" 
 									<div class='col col-auto text-left'>
 										<div class='row '>
 											<div class='col col-12'>
-												<a href='http://<?php echo $device_group->ip; ?>/'
+												<a href='http://<?php echo (!empty($device_group->username) && !empty($device_group->password)) ? $device_group->username . ":" . $device_group->password . "@" : "" ?><?php echo $device_group->ip; ?>/'
 												   target='_blank'
 												   title='<?php echo __(
 													   "LINK_OPEN_DEVICE_WEBUI",

--- a/tasmoadmin/pages/elements/devices_table.php
+++ b/tasmoadmin/pages/elements/devices_table.php
@@ -107,7 +107,7 @@
                     <?php endif; ?>
                     <td><?php echo $device_group->id; ?></td>
                     <td>
-                        <a href='http://<?php echo $device_group->ip; ?>/'
+                        <a href='http://<?php echo (!empty($device_group->username) && !empty($device_group->password)) ? $device_group->username . ":" . $device_group->password . "@" : "" ?><?php echo $device_group->ip; ?>/'
                            target='_blank'
                            title='<?php echo __(
                                "LINK_OPEN_DEVICE_WEBUI",


### PR DESCRIPTION
It's a relatively simple hack here, as it just check if username and password is set, then add it to the URL for automatic login on Tasmota's web UI. 

I'm a bit confused when I go through the code if the user didn't set the username (which should be "admin" by default) but rather the password only. On my end the behaviour is that the username will be simply empty if I edit a device, but will fallback to "admin" if I leave the field empty at the time of adding a new device in `devices.csv`. Also it seems when there's no username at all in `devices.csv` Tasmota will refuse the connection as username is not provided. I guess if this issue can be addressed, the code in this PR can be further improved (allows auto-login when username is not provided). 

Welcome suggestions 😃 