### PR TITLE
Set connect_timeout on device client

### DIFF
--- a/tasmoadmin/src/Sonoff.php
+++ b/tasmoadmin/src/Sonoff.php
@@ -26,6 +26,7 @@ class Sonoff
         $this->deviceRepository = $deviceRepository;
         $this->responseParser = new ResponseParser();
         $this->client = $client ?? new Client([
+            'connect_timeout' => 5,
             'timeout' => 5,
         ]);
     }


### PR DESCRIPTION
I noticed the connect_timeout configuration wasn't set  - set this to something realistic.