### PR TITLE
Fix routing for devices_details

### DIFF
--- a/tasmoadmin/includes/routes.php
+++ b/tasmoadmin/includes/routes.php
@@ -11,6 +11,7 @@ $routes->add('devices', new Route('/devices'));
 $routes->add('device_action', (new Route('/device_action/{action}/{device_id}'))->addDefaults(['device_id' => '-1']));
 $routes->add('device_config', new Route('/device_config/{device_id}'));
 $routes->add('device_update', new Route('/device_update'));
+$routes->add('devices_details', new Route('/devices_details'));
 $routes->add('upload', new Route('/upload'));
 $routes->add('upload_form', new Route('/upload_form'));
 $routes->add('backup', new Route('/backup'));


### PR DESCRIPTION
Noticed `/devices_details` routing wasn't properly mapped - not sure who uses this page as it's not linked anywhere.