### PR TITLE
By default only allow upgrades to newer versions

### DIFF
--- a/tasmoadmin/includes/header.php
+++ b/tasmoadmin/includes/header.php
@@ -84,6 +84,7 @@ $urlHelper = $container->get(UrlHelper::class);
                 nightmodeconfig: '<?php echo $Config->read("nightmode"); ?>',
                 update_fe_check: <?php echo $Config->read("update_fe_check"); ?> === 1,
                 force_upgrade: <?php echo $Config->read("force_upgrade"); ?> === 1,
+                update_newer_only: <?php echo $Config->read("update_newer_only"); ?> === 1,
             };
 		</script>
 		<script src="<?php echo $urlHelper->js("jquery", "node_modules/jquery/dist/"); ?>"></script>
@@ -114,6 +115,7 @@ $urlHelper = $container->get(UrlHelper::class);
 		<script src="<?php echo $urlHelper->js("tablesaw-init", "node_modules/tablesaw/dist/"); ?>"></script>
 		<script src="<?php echo $urlHelper->js("bootstrap-waitingfor", "node_modules/bootstrap-waitingfor/build/"); ?>"></script>
 		<script src="<?php echo $urlHelper->js("jquery.doubleScroll", "node_modules/jqdoublescroll/"); ?>"></script>
+		<script src="<?php echo $urlHelper->js("index", "node_modules/compare-versions/lib/umd/"); ?>"></script>
 
 		<script src="<?php echo $urlHelper->js("Sonoff"); ?>"></script>
 		<script src="<?php echo $urlHelper->js("app"); ?>"></script>

--- a/tasmoadmin/lang/en/lang.ini
+++ b/tasmoadmin/lang/en/lang.ini
@@ -119,6 +119,8 @@ CONFIG_AUTO_FIRMWARE_CHANNEL_HELP = "Auto firmware channel"
 CONFIG_AUTO_FIRMWARE_TITLE = "Auto Firmware"
 CONFIG_FORCE_UPGRADE = "Force Upgrade"
 CONFIG_FORCE_UPGRADE_HELP = "When set force upgrade irrespective of the device current version"
+CONFIG_UPDATE_NEWER_ONLY = "Update newer only"
+CONFIG_UPDATE_NEWER_ONLY_HELP = "Only upgrade if firmware version is newer than already installed"
 
 
 [DEVICE_ACTIONS]
@@ -460,6 +462,7 @@ BLOCK_UPDATE_ERROR_VERSION_COMPARE_MISMATCH = "Failed to update to $1 version is
 BLOCK_UPDATE_SLEEPING = "Sleeping for $1s..."
 BLOCK_UPDATE_FETCH_FAILED = "Failed to fetch trying again... attempts left $1 sleeping for $2s..."
 BLOCK_UPDATE_DEVICE_AT_TARGET_VERSION = "Device already at target version"
+BLOCK_UPDATE_DEVICE_NEWER_THAN_TARGET_VERSION = "Upgrade would be a downgrade"
 BLOCK_UPDATE_ATTEMPT_TO_VERSION = "Attempting upgrade to version $1"
 BLOCK_UPDATE_MINIMAL= "Performing minimal upgrade'"
 BLOCK_UPDATE_RESULTS = "Updated $1 out of $2 devices successfully"

--- a/tasmoadmin/package-lock.json
+++ b/tasmoadmin/package-lock.json
@@ -13,6 +13,7 @@
         "@wikimedia/jquery.i18n": "^1.0.9",
         "bootstrap": "^4.6.2",
         "bootstrap-waitingfor": "^1.2.7",
+        "compare-versions": "^6.1.0",
         "jqdoublescroll": "^1.0.0",
         "jquery": "^3.7.1",
         "js-cookie": "^3.0.5",
@@ -341,6 +342,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/tasmoadmin/package.json
+++ b/tasmoadmin/package.json
@@ -9,6 +9,7 @@
     "@wikimedia/jquery.i18n": "^1.0.9",
     "bootstrap": "^4.6.2",
     "bootstrap-waitingfor": "^1.2.7",
+    "compare-versions": "^6.1.0",
     "jqdoublescroll": "^1.0.0",
     "jquery": "^3.7.1",
     "js-cookie": "^3.0.5",

--- a/tasmoadmin/pages/site_config.php
+++ b/tasmoadmin/pages/site_config.php
@@ -17,7 +17,7 @@ if (isset($_POST["save"])) {
         $settings["login"] = "0";
     }
 
-    if (!isset($settings["check_for_updates"])) {
+	if (!isset($settings["check_for_updates"])) {
         $settings["check_for_updates"] = "0";
     }
 
@@ -37,6 +37,10 @@ if (isset($_POST["save"])) {
         $settings["update_be_check"] = "0";
     }
 
+	if (!isset($settings["update_newer_only"])) {
+        $settings["update_newer_only"] = "0";
+    }
+
     if (empty($settings["password"])) {
         unset($settings["password"]);
     } else {
@@ -48,7 +52,6 @@ if (isset($_POST["save"])) {
     }
 
     $Config->writeAll($settings);
-    //header( "Refresh:0" ); //fix for not updated config cuz of buffer
     $msg = __("MSG_USER_CONFIG_SAVED", "USER_CONFIG");
 }
 
@@ -266,6 +269,23 @@ $autoFirmwareChannels = ['stable', 'dev'];
                         <p class="small" style="padding-top:15px;">
                             <?php echo __("CONFIG_FORCE_UPGRADE_HELP", "USER_CONFIG"); ?>
 
+                        </p>
+                    </div>
+                </div>
+                <div class="form-group col col-12 col-sm-3">
+                    <label>&nbsp;</label>
+                    <div class="form-check custom-control custom-checkbox mb-5">
+                        <input class="form-check-input custom-control-input"
+                               type="checkbox"
+                               value="1"
+                               id="update_newer_only"
+                               name='update_newer_only' <?php echo $config["update_newer_only"] == "1"
+                            ? "checked=\"checked\"" : ""; ?>>
+                        <label class="form-check-label custom-control-label" for="update_newer_only" style='top:3px;'>
+                            <?php echo __("CONFIG_UPDATE_NEWER_ONLY", "USER_CONFIG"); ?>
+                        </label>
+                        <p class="small" style="padding-top:15px;">
+                            <?php echo __("CONFIG_UPDATE_NEWER_ONLY_HELP", "USER_CONFIG"); ?>
                         </p>
                     </div>
                 </div>

--- a/tasmoadmin/src/Config.php
+++ b/tasmoadmin/src/Config.php
@@ -36,6 +36,7 @@ class Config
         "show_search"           => "1",
         "update_fe_check"      => "0",
         "update_be_check"      => "1",
+        "update_newer_only"    => "1",
         "auto_update_channel"  => "stable",
         "force_upgrade"  => "0",
     ];


### PR DESCRIPTION
Add a new configuration option that allows upgrading to newer versions only.

Can be set to false in settings to allow downgrades.

![image](https://github.com/TasmoAdmin/TasmoAdmin/assets/713525/99ab64a3-22b8-4208-b570-4dd0ed9d3436)
