### PR TITLE
fix session lifetime

### DIFF
--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -41,8 +41,6 @@ define("_CSVFILE_", _DATADIR_."devices.csv");
 
 
 session_save_path(_TMPDIR_."sessions");
-ini_set('session.gc_maxlifetime', 356 * 24 * 60 * 60);
-session_set_cookie_params(356 * 24 * 60 * 60);
 session_name("TASMO_SESSION");
 session_start();
 

--- a/tasmoadmin/index.php
+++ b/tasmoadmin/index.php
@@ -7,8 +7,6 @@ use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Whoops\Handler\PrettyPageHandler;
 
-ob_start();
-
 include_once( "./includes/bootstrap.php" );
 
 


### PR DESCRIPTION
Resolves #1066

Previously session garbage collection was set to last for 1 year which seems insane - not sure why it was set to last so long :/

this change moves it back to the default of 24 minutes with the 1% change of it being cleaned up after that.