### PR TITLE
Remove redundant version from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   web:
     build:


### PR DESCRIPTION
No longer required - https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313