### PR TITLE
Control request concurrency

### DIFF
--- a/tasmoadmin/includes/container.php
+++ b/tasmoadmin/includes/container.php
@@ -25,7 +25,8 @@ $container->set(HttpClientFactory::class, new HttpClientFactory($container->get(
 $container->set(DeviceRepository::class, new DeviceRepository(_CSVFILE_, _TMPDIR_));
 $container->set(Sonoff::class, new Sonoff(
     $container->get(DeviceRepository::class),
-    $container->get(HttpClientFactory::class)->getClient()
+    $container->get(HttpClientFactory::class)->getClient(),
+    $container->get(Config::class)
 ));
 $container->set(i18n::class, new i18n());
 $container->set(BackupHelper::class, new BackupHelper(

--- a/tasmoadmin/lang/en/lang.ini
+++ b/tasmoadmin/lang/en/lang.ini
@@ -125,6 +125,8 @@ CONFIG_CONNECT_TIMEOUT_HELP = "The timeout in seconds, when connecting to a devi
 CONFIG_TIMEOUT = "Timeout"
 CONFIG_TIMEOUT_HELP = "The timeout in seconds, when fetching data from a device"
 CONFIG_ADVANCED = "Advanced"
+CONFIG_REQUEST_CONCURRENCY = "Request concurrency"
+CONFIG_REQUEST_CONCURRENCY_HELP = "The number of requests to concurrently dispatch"
 
 
 [DEVICE_ACTIONS]

--- a/tasmoadmin/pages/site_config.php
+++ b/tasmoadmin/pages/site_config.php
@@ -420,7 +420,7 @@ $autoFirmwareChannels = ['stable', 'dev'];
                 <div class="form-group col col-12">
                     <h2><?php echo __("CONFIG_ADVANCED", "USER_CONFIG"); ?></h2>
                 </div>
-                <div class="form-group col col-12 col-sm-6">
+                <div class="form-group col col-12 col-sm-4">
                     <label for="connect_timeout">
                         <?php echo __("CONFIG_CONNECT_TIMEOUT", "USER_CONFIG"); ?>
                     </label>
@@ -435,7 +435,7 @@ $autoFirmwareChannels = ['stable', 'dev'];
                         <?php echo __("CONFIG_CONNECT_TIMEOUT_HELP", "USER_CONFIG"); ?>
                     </small>
                 </div>
-                <div class="form-group col col-12 col-sm-6">
+                <div class="form-group col col-12 col-sm-4">
                     <label for="timeout">
                         <?php echo __("CONFIG_TIMEOUT", "USER_CONFIG"); ?>
                     </label>
@@ -448,6 +448,21 @@ $autoFirmwareChannels = ['stable', 'dev'];
                     >
                     <small id="timeoutHelp" class="form-text text-muted">
                         <?php echo __("CONFIG_TIMEOUT_HELP", "USER_CONFIG"); ?>
+                    </small>
+                </div>
+                <div class="form-group col col-12 col-sm-4">
+                    <label for="request_concurrency">
+                        <?php echo __("CONFIG_REQUEST_CONCURRENCY", "USER_CONFIG"); ?>
+                    </label>
+                    <input type="number"
+                           class="form-control"
+                           id="request_concurrency"
+                           name='request_concurrency'
+                           placeholder="<?php echo __("PLEASE_ENTER"); ?>"
+                           value='<?php echo $config["request_concurrency"]; ?>'
+                    >
+                    <small id="requestConcurrencyHelp" class="form-text text-muted">
+                        <?php echo __("CONFIG_REQUEST_CONCURRENCY_HELP", "USER_CONFIG"); ?>
                     </small>
                 </div>
             </div>

--- a/tasmoadmin/src/Config.php
+++ b/tasmoadmin/src/Config.php
@@ -40,7 +40,7 @@ class Config
         'force_upgrade' => '0',
         'connect_timeout' => '5',
         'timeout' => '5',
-        'concurrent_requests' => 50,
+        'request_concurrency' => '50',
     ];
 
     private array $cachedConfig = [];
@@ -197,9 +197,9 @@ class Config
         return (int) $this->read('timeout');
     }
 
-    public function getConcurrentRequests(): int
+    public function getRequestConcurrency(): int
     {
-        return (int) $this->read('concurrent_requests');
+        return (int) $this->read('request_concurrency');
     }
 
     private function cleanConfig(): array

--- a/tasmoadmin/src/Config.php
+++ b/tasmoadmin/src/Config.php
@@ -40,6 +40,7 @@ class Config
         'force_upgrade' => '0',
         'connect_timeout' => '5',
         'timeout' => '5',
+        'concurrent_requests' => 50,
     ];
 
     private array $cachedConfig = [];
@@ -194,6 +195,11 @@ class Config
     public function getTimeout(): int
     {
         return (int) $this->read('timeout');
+    }
+
+    public function getConcurrentRequests(): int
+    {
+        return (int) $this->read('concurrent_requests');
     }
 
     private function cleanConfig(): array

--- a/tasmoadmin/src/Sonoff.php
+++ b/tasmoadmin/src/Sonoff.php
@@ -269,7 +269,7 @@ class Sonoff
 
         $results = [];
         $pool = new Pool($this->client, $requests($urlData), [
-            'concurrency' => $this->config->getConcurrentRequests(),
+            'concurrency' => $this->config->getRequestConcurrency(),
             'fulfilled' => function (Response $response, $index) use (&$results, $urlData) {
                 $results[$urlData[$index]['id']] = $this->responseParser->processResult($response->getBody()->getContents());
             },
@@ -327,7 +327,7 @@ class Sonoff
 
         $results = [];
         $pool = new Pool($this->client, $requests($urls), [
-            'concurrency' => $this->config->getConcurrentRequests(),
+            'concurrency' => $this->config->getRequestConcurrency(),
             'fulfilled' => function (Response $response, $index) use (&$results) {
                 $results[] = $this->responseParser->processResult($response->getBody()->getContents());
             },

--- a/tasmoadmin/src/Sonoff.php
+++ b/tasmoadmin/src/Sonoff.php
@@ -4,7 +4,9 @@ namespace TasmoAdmin;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Promise;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use TasmoAdmin\Tasmota\ResponseParser;
 
 class Sonoff
@@ -17,11 +19,14 @@ class Sonoff
 
     private Client $client;
 
-    public function __construct(DeviceRepository $deviceRepository, Client $client)
+    private Config $config;
+
+    public function __construct(DeviceRepository $deviceRepository, Client $client, Config $config)
     {
         $this->deviceRepository = $deviceRepository;
         $this->responseParser = new ResponseParser();
         $this->client = $client;
+        $this->config = $config;
     }
 
     public function getAllStatus(Device $device): \stdClass
@@ -247,22 +252,31 @@ class Sonoff
 
         $devices = $this->getDevices();
 
-        $promises = [];
+        $urlData = [];
         foreach ($devices as $device) {
             $url = $this->buildCmndUrl($device, self::COMMAND_INFO_STATUS_ALL);
-            $promises[$device->id] = $this->client->getAsync($url);
+            $urlData[] = [
+                'id' => $device->id,
+                'url' => $url,
+            ];
         }
 
-        $responses = Promise\Utils::settle($promises)->wait();
+        $requests = function ($urls) {
+            foreach ($urls as $url) {
+                yield new Request('GET', $url['url']);
+            }
+        };
 
         $results = [];
-        foreach ($responses as $deviceId => $response) {
-            if ('rejected' === $response['state']) {
-                continue;
-            }
+        $pool = new Pool($this->client, $requests($urlData), [
+            'concurrency' => $this->config->getConcurrentRequests(),
+            'fulfilled' => function (Response $response, $index) use (&$results, $urlData) {
+                $results[$urlData[$index]['id']] = $this->responseParser->processResult($response->getBody()->getContents());
+            },
+        ]);
 
-            $results[$deviceId] = $this->responseParser->processResult($response['value']->getBody()->getContents());
-        }
+        $promise = $pool->promise();
+        $promise->wait();
 
         ini_set('max_execution_time', Constants::DEFAULT_MAX_EXECUTION_TIME);
 
@@ -305,25 +319,22 @@ class Sonoff
     {
         ini_set('max_execution_time', Constants::EXTENDED_MAX_EXECUTION_TIME);
 
-        $promises = [];
-        foreach ($urls as $url) {
-            $promises[$url] = $this->client->getAsync($url);
-        }
-
-        $responses = Promise\Utils::settle($promises)->wait();
+        $requests = function ($urls) {
+            foreach ($urls as $url) {
+                yield new Request('GET', $url);
+            }
+        };
 
         $results = [];
-        foreach ($responses as $response) {
-            if ('rejected' === $response['state']) {
-                continue;
-            }
+        $pool = new Pool($this->client, $requests($urls), [
+            'concurrency' => $this->config->getConcurrentRequests(),
+            'fulfilled' => function (Response $response, $index) use (&$results) {
+                $results[] = $this->responseParser->processResult($response->getBody()->getContents());
+            },
+        ]);
 
-            if (200 !== $response['value']->getStatusCode()) {
-                continue;
-            }
-
-            $results[] = $this->responseParser->processResult($response['value']->getBody()->getContents());
-        }
+        $promise = $pool->promise();
+        $promise->wait();
 
         ini_set('max_execution_time', Constants::DEFAULT_MAX_EXECUTION_TIME);
 


### PR DESCRIPTION
To stop TA sending as many requests as possible use a request pool to limit concurrency.

![image](https://github.com/user-attachments/assets/af28938f-778d-484c-8555-bc8900249c74)
