### PR TITLE
Pin composer to 2.8.6

### DIFF
--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -10,7 +10,7 @@ RUN npm ci \
     && npm run build \
     && rm -rf node_modules/
 
-FROM composer AS builder
+FROM composer:2.8.6 AS builder
 
 COPY --from=node-builder /tasmoadmin  /tasmoadmin
 


### PR DESCRIPTION
Looks like 2.8.7 might have broke and 2.8.8 is not available yet.