### PR TITLE
fix: use non-deprecated env usage in docker

### DIFF
--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -89,9 +89,9 @@ RUN apk add --no-cache --virtual .build-dependencies \
         /tmp/*
 
 # Environment variables
-ENV BUILD_VERSION ${BUILD_VERSION}
-ENV BUILD_REF ${BUILD_REF}
-ENV SSL false
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV BUILD_REF=${BUILD_REF}
+ENV SSL=false
 
 RUN echo "fastcgi_param BUILD_VERSION ${BUILD_VERSION};" >> /etc/nginx/fastcgi_params
 RUN echo "fastcgi_param BUILD_REF ${BUILD_REF};" >> /etc/nginx/fastcgi_params


### PR DESCRIPTION
Previous usage is deprecated.

```
 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 94)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 92)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 93)
Dockerfile.alpine-tmpl:14
```