### PR TITLE
feat: allow skipping authentication via NO_AUTH environment variable

### DIFF
--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -90,7 +90,7 @@ $langHelper = new JsonLanguageHelper(
 );
 $langHelper->dumpJson();
 
-if ((isset($_SESSION['login']) && '1' == $_SESSION['login']) || '0' == $Config->read('login')) {
+if ((isset($_SESSION['login']) && '1' == $_SESSION['login']) || '0' == $Config->read('login') || getenv('NO_AUTH')) {
     $loggedin = true;
 }
 


### PR DESCRIPTION
Closes #1519

## Summary

Adds support for a `NO_AUTH` environment variable that, when set, bypasses the built-in login requirement. Useful for deployments where authentication is handled externally (e.g. a reverse proxy).