### PR TITLE
reduce dependency PR noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "rebaseWhen": "conflicted",
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 1,
+  "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "extends": [
     "config:recommended"
   ],
@@ -8,6 +14,70 @@
     "enabled": true
   },
   "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "groupName": "npm non-major dependencies",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
+    {
+      "groupName": "composer non-major dependencies",
+      "matchManagers": [
+        "composer"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
+    {
+      "groupName": "github-actions non-major dependencies",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
+    {
+      "groupName": "docker non-major dependencies",
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose",
+        "regex"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
+    {
+      "groupName": "node-minify packages",
+      "matchPackageNames": [
+        "@node-minify/core",
+        "@node-minify/clean-css",
+        "@node-minify/terser"
+      ]
+    },
     {
       "groupName": "symfony",
       "versioning": "composer",


### PR DESCRIPTION
## What changed
- limit Renovate to 3 concurrent PRs and 1 PR per hour
- require dashboard approval for major updates
- group non-major npm, composer, GitHub Actions, and Docker updates
- disable Renovate vulnerability alert PRs so Dependabot security PRs are the single remediation path
- add an explicit node-minify group to avoid three separate churn PRs

## Why
Open dependency chores had become noisy and duplicative. The repo had overlapping security PRs from Renovate and Dependabot plus several long-lived failing upgrade PRs. This narrows the queue to a smaller, more reviewable set.

## Impact
- fewer simultaneous chore PRs
- less duplicate security noise
- major/toolchain bumps move behind intentional approval instead of staying open indefinitely

## Validation
- `jq . .github/renovate.json`
- reviewed current Renovate config against current Renovate documentation
