### PR TITLE
Add DDEV development setup

### DIFF
--- a/.ddev/commands/web/build-assets
+++ b/.ddev/commands/web/build-assets
@@ -1,0 +1,5 @@
+#!/bin/bash
+## Description: Build frontend assets for TasmoAdmin
+set -eu
+
+npm run build

--- a/.ddev/commands/web/install-deps
+++ b/.ddev/commands/web/install-deps
@@ -1,0 +1,6 @@
+#!/bin/bash
+## Description: Install PHP and Node dependencies for TasmoAdmin
+set -eu
+
+composer install
+npm ci

--- a/.ddev/commands/web/qa
+++ b/.ddev/commands/web/qa
@@ -1,0 +1,5 @@
+#!/bin/bash
+## Description: Run the PHP quality checks defined by composer
+set -eu
+
+composer run quality

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,21 @@
+name: tasmoadmin
+type: php
+docroot: tasmoadmin
+php_version: "8.5"
+webserver_type: apache-fpm
+xdebug_enabled: false
+omit_containers:
+  - db
+use_dns_when_possible: true
+composer_version: "2"
+composer_root: tasmoadmin
+nodejs_version: "22"
+web_environment:
+  - TASMO_DEBUG=1
+  - TASMO_TMPDIR=/tmp/tasmoadmin/
+corepack_enable: false
+working_dir:
+  web: /var/www/html/tasmoadmin
+hooks:
+  post-start:
+    - exec: "mkdir -p /tmp/tasmoadmin/sessions /tmp/tasmoadmin/cache/i18n /var/www/html/tasmoadmin/tmp /var/www/html/tasmoadmin/data/firmwares /var/www/html/tasmoadmin/data/updates && touch /var/www/html/tasmoadmin/.dockerenv"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,51 @@ Then visit http://localhost:8000
 
 Persistent storage within this setup is located in the `.storage` folder.
 
+### DDEV
+
+The repository also includes a DDEV setup for local development. It uses:
+
+* `apache-fpm`
+* PHP `8.5`
+* Node.js `22`
+* no database container
+
+Start the environment with:
+
+```bash
+ddev start
+```
+
+Install PHP and Node.js dependencies:
+
+```bash
+ddev install-deps
+```
+
+Build the frontend assets:
+
+```bash
+ddev build-assets
+```
+
+Then visit `https://tasmoadmin.ddev.site`.
+
+Common development commands:
+
+```bash
+ddev ssh
+ddev exec phpunit
+ddev qa
+ddev restart
+ddev stop
+```
+
+Notes:
+
+* `ddev install-deps` runs `composer install` and `npm ci` in `tasmoadmin/`
+* `ddev build-assets` runs the frontend build
+* `ddev qa` runs the Composer quality checks
+
 
 ## Translations
 


### PR DESCRIPTION
## What changed
- add a DDEV project config for TasmoAdmin with `tasmoadmin/` as the docroot
- add DDEV helper commands for installing dependencies, building assets, and running quality checks
- document the DDEV development workflow in the README

## Why
- make local development reproducible without relying on the existing docker-compose workflow
- keep the app's expected runtime behavior intact under DDEV

## Validation
- `ddev restart`
- `ddev install-deps`
- `ddev build-assets`
- `ddev exec 'vendor/bin/phpunit --display-deprecations'`
