### PR TITLE
feat: allow skipping authentication via NO_AUTH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Some environment variables are configured to allow easier customisation of the a
 
 - `TASMO_DATADIR` - Path where to store data. If not provided defaults to `./tasmoadmin/data`
 - `TASMO_BASEURL` - Customise the base URL for the application
+- `NO_AUTH` - Set to `true` to bypass the built-in login when authentication is handled externally
 
 ## Development
 

--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -90,7 +90,7 @@ $langHelper = new JsonLanguageHelper(
 );
 $langHelper->dumpJson();
 
-if ((isset($_SESSION['login']) && '1' == $_SESSION['login']) || '0' == $Config->read('login')) {
+if ((isset($_SESSION['login']) && '1' == $_SESSION['login']) || '0' == $Config->read('login') || getenv('NO_AUTH')) {
     $loggedin = true;
 }
 

--- a/tasmoadmin/includes/bootstrap.php
+++ b/tasmoadmin/includes/bootstrap.php
@@ -51,6 +51,7 @@ require_once _APPROOT_.'vendor/autoload.php';
 
 use Selective\Container\Container;
 use TasmoAdmin\Config;
+use TasmoAdmin\Helper\EnvironmentHelper;
 use TasmoAdmin\Helper\JsonLanguageHelper;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run;
@@ -90,7 +91,10 @@ $langHelper = new JsonLanguageHelper(
 );
 $langHelper->dumpJson();
 
-if ((isset($_SESSION['login']) && '1' == $_SESSION['login']) || '0' == $Config->read('login') || getenv('NO_AUTH')) {
+if ((isset($_SESSION['login']) && '1' == $_SESSION['login'])
+    || '0' == $Config->read('login')
+    || EnvironmentHelper::isEnabled('NO_AUTH')
+) {
     $loggedin = true;
 }
 

--- a/tasmoadmin/src/Helper/EnvironmentHelper.php
+++ b/tasmoadmin/src/Helper/EnvironmentHelper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace TasmoAdmin\Helper;
+
+class EnvironmentHelper
+{
+    public static function isEnabled(string $variable): bool
+    {
+        return filter_var(getenv($variable), FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/tasmoadmin/tests/Helper/EnvironmentHelperTest.php
+++ b/tasmoadmin/tests/Helper/EnvironmentHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\TasmoAdmin\Helper;
+
+use PHPUnit\Framework\TestCase;
+use TasmoAdmin\Helper\EnvironmentHelper;
+
+class EnvironmentHelperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('NO_AUTH');
+    }
+
+    public function testIsEnabledReturnsTrueForTruthyValues(): void
+    {
+        putenv('NO_AUTH=true');
+        self::assertTrue(EnvironmentHelper::isEnabled('NO_AUTH'));
+
+        putenv('NO_AUTH=1');
+        self::assertTrue(EnvironmentHelper::isEnabled('NO_AUTH'));
+    }
+
+    public function testIsEnabledReturnsFalseForFalsyValues(): void
+    {
+        putenv('NO_AUTH=false');
+        self::assertFalse(EnvironmentHelper::isEnabled('NO_AUTH'));
+
+        putenv('NO_AUTH=0');
+        self::assertFalse(EnvironmentHelper::isEnabled('NO_AUTH'));
+    }
+
+    public function testIsEnabledReturnsFalseWhenUnset(): void
+    {
+        putenv('NO_AUTH');
+        self::assertFalse(EnvironmentHelper::isEnabled('NO_AUTH'));
+    }
+}


### PR DESCRIPTION
Closes #1519
Supersedes #1520, which could not be updated from the upstream repository because maintainer edits were disabled on the fork.

## Summary

Adds support for a `NO_AUTH` environment variable that bypasses the built-in login requirement when authentication is handled externally.

This replacement also fixes the env parsing so only actual boolean truthy values enable the bypass. Values like `false` or `0` continue to enforce login.

## Validation

- `ddev exec 'vendor/bin/phpunit --display-deprecations'`
