### PR TITLE
Fix i18n loading and language redirects

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+mapfile -d '' staged_files < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [ ${#staged_files[@]} -eq 0 ]; then
+    exit 0
+fi
+
+if command -v pre-commit >/dev/null 2>&1; then
+    pre-commit run --files "${staged_files[@]}"
+else
+    echo "[pre-commit] 'pre-commit' is not installed; skipping .pre-commit-config.yaml hooks."
+fi
+
+"$repo_root/scripts/run-pre-commit-checks.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@
 portable/xampp.zip
 
 /.storage/
+/goals/

--- a/scripts/run-pre-commit-checks.sh
+++ b/scripts/run-pre-commit-checks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+mapfile -d '' staged_files < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [ ${#staged_files[@]} -eq 0 ]; then
+    exit 0
+fi
+
+if ! command -v ddev >/dev/null 2>&1; then
+    echo "[pre-commit] ddev is required for local checks."
+    exit 1
+fi
+
+if ! ddev exec true >/dev/null 2>&1; then
+    echo "[pre-commit] ddev is not running. Start it with 'ddev start' and try again."
+    exit 1
+fi
+
+matches_staged() {
+    local pattern="$1"
+    local file
+
+    for file in "${staged_files[@]}"; do
+        if [[ "$file" =~ $pattern ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+run_in_tasmoadmin() {
+    local description="$1"
+    shift
+
+    echo "[pre-commit] $description"
+    ddev exec bash -lc "cd /var/www/html/tasmoadmin && $*"
+}
+
+php_pattern='^tasmoadmin/.*\.php$|^tasmoadmin/(composer\.json|composer\.lock|phpstan\.neon\.dist|phpunit\.xml\.dist|\.php-cs-fixer\.dist\.php)$'
+frontend_pattern='^tasmoadmin/(resources/js/|resources/scss/|tests/js/)|^tasmoadmin/(package\.json|package-lock\.json|esbuild\.mjs|minify\.js)$'
+
+if matches_staged "$php_pattern"; then
+    run_in_tasmoadmin "Running php-cs-fixer" "./vendor/bin/php-cs-fixer fix --dry-run --allow-unsupported-php-version=yes"
+    run_in_tasmoadmin "Running phpstan" "./vendor/bin/phpstan"
+    run_in_tasmoadmin "Running phpunit" "./vendor/bin/phpunit --display-deprecations"
+fi
+
+if matches_staged "$frontend_pattern"; then
+    run_in_tasmoadmin "Running prettier:check" "npm run prettier:check"
+    run_in_tasmoadmin "Running JS tests" "npm run test:js"
+    run_in_tasmoadmin "Running asset build" "npm run build"
+fi

--- a/tasmoadmin/index.php
+++ b/tasmoadmin/index.php
@@ -98,10 +98,16 @@ $context->fromRequest($request);
 $matcher = new UrlMatcher($routes, $context);
 
 $authByPassedPages = ['login', 'change_language'];
+$isPublicI18nRequest = 'actions' === $request->getPathInfo()
+    && $request->query->has('i18n');
 
 try {
     $matched = $matcher->match($request->getPathInfo());
-    if (!$loggedin && !in_array($matched['_route'], $authByPassedPages)) {
+    if (
+        !$loggedin
+        && !$isPublicI18nRequest
+        && !in_array($matched['_route'], $authByPassedPages)
+    ) {
         if ('render_template' === $matched['_controller']) {
             header('Location: '._BASEURL_.'login');
 

--- a/tasmoadmin/pages/actions.php
+++ b/tasmoadmin/pages/actions.php
@@ -38,6 +38,26 @@ if (isset($_GET['doAjaxAll'])) {
     exit;
 }
 
+if (isset($_GET['i18n'])) {
+    $requestedLang = $_GET['lang'] ?? $lang;
+    $supportedLanguages = \TasmoAdmin\Helper\SupportedLanguageHelper::getSupportedLanguages();
+    $language = array_key_exists($requestedLang, $supportedLanguages) ? $requestedLang : $lang;
+    $cacheFile = _TMPDIR_.'cache/i18n/json_i18n_'.$language.'.cache.json';
+
+    if (!is_file($cacheFile)) {
+        http_response_code(404);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => 'Language cache not found']);
+
+        exit;
+    }
+
+    header('Content-Type: application/json');
+    readfile($cacheFile);
+
+    exit;
+}
+
 if (isset($_GET['downloadBackup'])) {
     $backup = $container->get(BackupHelper::class);
 

--- a/tasmoadmin/pages/actions.php
+++ b/tasmoadmin/pages/actions.php
@@ -3,6 +3,7 @@
 use TasmoAdmin\Backup\BackupHelper;
 use TasmoAdmin\DeviceRepository;
 use TasmoAdmin\Helper\FirmwareFolderHelper;
+use TasmoAdmin\Helper\SupportedLanguageHelper;
 use TasmoAdmin\Sonoff;
 
 $Sonoff = $container->get(Sonoff::class);
@@ -40,7 +41,7 @@ if (isset($_GET['doAjaxAll'])) {
 
 if (isset($_GET['i18n'])) {
     $requestedLang = $_GET['lang'] ?? $lang;
-    $supportedLanguages = \TasmoAdmin\Helper\SupportedLanguageHelper::getSupportedLanguages();
+    $supportedLanguages = SupportedLanguageHelper::getSupportedLanguages();
     $language = array_key_exists($requestedLang, $supportedLanguages) ? $requestedLang : $lang;
     $cacheFile = _TMPDIR_.'cache/i18n/json_i18n_'.$language.'.cache.json';
 

--- a/tasmoadmin/pages/change_language.php
+++ b/tasmoadmin/pages/change_language.php
@@ -6,4 +6,6 @@ $redirectHelper = $container->get(RedirectHelper::class);
 
 $_SESSION['lang'] = $new_lang;
 $redirect = $redirectHelper->getValidRedirectUrl($_GET['current'] ?? _BASEURL_, _BASEURL_);
-header("Location: {$redirect}");
+header("Location: {$redirect}", true, 302);
+
+exit;

--- a/tasmoadmin/pages/login.php
+++ b/tasmoadmin/pages/login.php
@@ -10,7 +10,9 @@ $title = __('LOGIN', 'PAGE_TITLES');
 $page = 'login';
 
 if (0 == $Config->read('login')) {
-    header('Location: '._BASEURL_);
+    header('Location: '._BASEURL_, true, 302);
+
+    exit;
 }
 
 $loginHelper = new LoginHelper($Config);
@@ -20,14 +22,14 @@ if (!empty($_POST)) {
     if (isset($_REQUEST['register']) && ('' === $user || '' === $password)) {
         $loginHelper->register($_REQUEST['username'], $_REQUEST['password']);
         $_SESSION['login'] = '1';
-        header('Location: '._BASEURL_.$home);
+        header('Location: '._BASEURL_.$home, true, 302);
 
         exit;
     }
     if (isset($_REQUEST['login'])) {
         if ($user === $_REQUEST['username'] && $loginHelper->login($_REQUEST['password'], $password)) {
             $_SESSION['login'] = '1';
-            header('Location: '._BASEURL_.$home);
+            header('Location: '._BASEURL_.$home, true, 302);
 
             exit;
         }

--- a/tasmoadmin/resources/js/app.js
+++ b/tasmoadmin/resources/js/app.js
@@ -9,8 +9,7 @@ window.sonoff = sonoff;
 let nightmode = false;
 
 const lang = $("html").attr("lang");
-const i18nfile =
-  config.base_url + "tmp/cache/i18n/json_i18n_" + lang + ".cache.json";
+const i18nfile = `${config.base_url}actions?i18n=1&lang=${encodeURIComponent(lang)}`;
 $.ajax({
   dataType: "json",
   url: i18nfile,

--- a/tasmoadmin/src/Helper/JsonLanguageHelper.php
+++ b/tasmoadmin/src/Helper/JsonLanguageHelper.php
@@ -91,6 +91,6 @@ class JsonLanguageHelper
     {
         return
             filemtime($cacheFile) > filemtime($this->languageFile)
-            || filemtime($cacheFile) > filemtime($this->fallbackLanguageFile);
+            && filemtime($cacheFile) > filemtime($this->fallbackLanguageFile);
     }
 }

--- a/tasmoadmin/tests/Helper/JsonLanguageHelperTest.php
+++ b/tasmoadmin/tests/Helper/JsonLanguageHelperTest.php
@@ -12,9 +12,18 @@ class JsonLanguageHelperTest extends TestCase
 {
     private vfsStreamDirectory $root;
 
+    private ?string $tempDir = null;
+
     public function setUp(): void
     {
         $this->root = vfsStream::setup();
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->tempDir !== null && is_dir($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
     }
 
     public function testDumpJson(): void
@@ -38,5 +47,76 @@ class JsonLanguageHelperTest extends TestCase
                 'WORLD' => 'world',
             ],
         ], json_decode(file_get_contents($this->root->getChild('json_i18n_de.cache.json')->url()), true));
+    }
+
+    public function testDumpJsonRegeneratesCacheWhenFallbackLanguageChanges(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/json-language-helper-'.bin2hex(random_bytes(8));
+        mkdir($this->tempDir);
+
+        $languageFile = $this->tempDir.'/language_de.ini';
+        $fallbackLanguageFile = $this->tempDir.'/language_en.ini';
+        $cacheDir = $this->tempDir.'/cache';
+        mkdir($cacheDir);
+
+        file_put_contents($languageFile, "HELLO = \"hallo\"\n");
+        touch($languageFile, time() - 20);
+
+        file_put_contents($fallbackLanguageFile, "HELLO = \"hello\"\nWORLD = \"world\"\n");
+        touch($fallbackLanguageFile, time() - 5);
+
+        $cacheFile = $cacheDir.'/json_i18n_de.cache.json';
+        file_put_contents($cacheFile, json_encode([
+            'de' => [
+                'HELLO' => 'hallo',
+            ],
+            'en' => [
+                'HELLO' => 'hello',
+            ],
+        ]));
+        touch($cacheFile, time() - 10);
+
+        $jsonLanguageHelper = new JsonLanguageHelper(
+            'de',
+            $languageFile,
+            'en',
+            $fallbackLanguageFile,
+            $cacheDir
+        );
+
+        $jsonLanguageHelper->dumpJson();
+
+        self::assertEquals([
+            'de' => [
+                'HELLO' => 'hallo',
+            ],
+            'en' => [
+                'HELLO' => 'hello',
+                'WORLD' => 'world',
+            ],
+        ], json_decode(file_get_contents($cacheFile), true));
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        $entries = scandir($directory);
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $directory.'/'.$entry;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
     }
 }

--- a/tasmoadmin/tests/Helper/JsonLanguageHelperTest.php
+++ b/tasmoadmin/tests/Helper/JsonLanguageHelperTest.php
@@ -21,7 +21,7 @@ class JsonLanguageHelperTest extends TestCase
 
     public function tearDown(): void
     {
-        if ($this->tempDir !== null && is_dir($this->tempDir)) {
+        if (null !== $this->tempDir && is_dir($this->tempDir)) {
             $this->removeDirectory($this->tempDir);
         }
     }
@@ -100,12 +100,12 @@ class JsonLanguageHelperTest extends TestCase
     private function removeDirectory(string $directory): void
     {
         $entries = scandir($directory);
-        if ($entries === false) {
+        if (false === $entries) {
             return;
         }
 
         foreach ($entries as $entry) {
-            if ($entry === '.' || $entry === '..') {
+            if ('.' === $entry || '..' === $entry) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- fix stale JSON language cache invalidation when the fallback language file changes
- serve the browser i18n catalog through `actions?i18n=1` so translations load when `TASMO_TMPDIR` is outside the web root
- allow that specific i18n request without auth, and make language/login redirects return real 302 responses
- ignore the local `goals/` folder

## Why
The app was writing its JSON language cache to `_TMPDIR_`, which is `/tmp/tasmoadmin/` in DDEV. The frontend still tried to fetch translations from `/tmp/cache/i18n/...`, which returned 404 and left `$.i18n()` unloaded. Separately, the language switch route emitted a `Location` header but still completed as a normal 200 response, causing a blank page.

## Impact
- device uptime labels render translated values again instead of raw `UPTIME_SHORT_*` keys
- language switching redirects back to the requested page instead of showing a white page
- the shared JS bundle can still load translations on public pages because only the i18n catalog request bypasses auth

## Validation
- `ddev exec ./vendor/bin/phpunit tests/Helper/JsonLanguageHelperTest.php --display-deprecations`
- `ddev exec ./vendor/bin/phpstan`
- `ddev exec npm run build`
- verified in Chrome DevTools that `/devices` shows translated uptime values and `change_language/{lang}?current=/devices` redirects back correctly
- verified `GET /actions?i18n=1&lang=en` returns JSON without auth
