### PR TITLE
Migrate Docker CI to Buildx

### DIFF
--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -33,10 +33,6 @@ ARG BUILD_VERSION=dev
 # Dependency versions
 ARG S6_OVERLAY_VERSION=3.1.6.2
 
-# Setup Qemu
-ARG QEMU_ARCH=x86_64
-COPY .docker/_tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
-
 # Install base system
 ARG BUILD_ARCH=amd64
 

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -2,7 +2,6 @@
 set -o errexit
 
 TARGET=ghcr.io/tasmoadmin/tasmoadmin
-QEMU_VERSION=v6.1.0-8
 ALPINE_VERSION=3.24
 BUILD_REF="${BUILD_REF:=dev}"
 BUILD_VERSION="${BUILD_VERSION:=dev}"
@@ -52,8 +51,8 @@ main() {
 }
 
 docker_prepare() {
-    # Prepare qemu to build images other then x86_64 on travis
-    prepare_qemu
+    echo "DOCKER PREPARE: ensuring buildx is available."
+    ensure_buildx
 }
 
 docker_build() {
@@ -65,17 +64,17 @@ docker_build() {
 
 docker_build_amd64() {
     echo "DOCKER BUILD: Build amd64."
-    docker build --progress=plain --platform linux/amd64 --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=amd64/alpine:${ALPINE_VERSION} --build-arg BUILD_ARCH=amd64 --build-arg QEMU_ARCH=x86_64 --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-amd64 .
+    docker_build_platform linux/amd64 amd64/alpine:${ALPINE_VERSION} amd64 ${TARGET}:build-alpine-amd64
 }
 
 docker_build_arm() {
     echo "DOCKER BUILD: Build arm."
-    docker build --progress=plain --platform linux/arm/v7 --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=arm32v7/alpine:${ALPINE_VERSION} --build-arg BUILD_ARCH=arm32v7 --build-arg QEMU_ARCH=arm --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-arm32v7 .
+    docker_build_platform linux/arm/v7 arm32v7/alpine:${ALPINE_VERSION} arm32v7 ${TARGET}:build-alpine-arm32v7
 }
 
 docker_build_arm64()  {
     echo "DOCKER BUILD: Build arm64."
-    docker build --progress=plain --platform linux/arm64 --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=arm64v8/alpine:${ALPINE_VERSION} --build-arg BUILD_ARCH=aarch64 --build-arg QEMU_ARCH=aarch64 --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-arm64v8 .
+    docker_build_platform linux/arm64 arm64v8/alpine:${ALPINE_VERSION} aarch64 ${TARGET}:build-alpine-arm64v8
 }
 
 docker_test() {
@@ -236,17 +235,26 @@ docker_manifest_list_version_os_arch() {
   docker manifest push $TARGET:$BUILD_VERSION-alpine-arm64v8
 }
 
+docker_build_platform() {
+    local platform="$1"
+    local base_image="$2"
+    local build_arch="$3"
+    local tag="$4"
 
-prepare_qemu(){
-    echo "PREPARE: Qemu"
-    # Prepare qemu to build non amd64 / x86_64 images
-    mkdir -p .docker/_tmp
-    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    pushd .docker/_tmp &&
-    curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&
-    curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz &&
-    curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
-    popd
+    ensure_buildx
+
+    docker buildx build --progress=plain --load --platform "${platform}" \
+        --build-arg BUILD_REF="${BUILD_REF}" \
+        --build-arg BUILD_DATE="$(date +"%Y-%m-%dT%H:%M:%SZ")" \
+        --build-arg BUILD_VERSION="${BUILD_VERSION}" \
+        --build-arg BUILD_FROM="${base_image}" \
+        --build-arg BUILD_ARCH="${build_arch}" \
+        --file ./.docker/Dockerfile.alpine-tmpl \
+        --tag "${tag}" .
+}
+
+ensure_buildx() {
+    docker buildx inspect >/dev/null 2>&1 || docker buildx create --use --name tasmoadmin-builder >/dev/null
 }
 
 main $1

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -154,17 +154,6 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "alpine"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "//.docker/docker.sh/"
-      ],
-      "matchStrings": [
-        "QEMU_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "multiarch/qemu-user-static"
     }
   ]
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,9 +152,12 @@ jobs:
       BUILD_VERSION: ${{ github.ref_name }}
     steps:
     - uses: actions/checkout@v6
-    - name: Prepare
-      run: |
-        ./.docker/docker.sh prepare
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+      with:
+        platforms: arm64,arm
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
     - name: Build docker images
       run: ./.docker/docker.sh build_${{ matrix.arch }}
     - name: Test docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
-    - name: Prepare
-      run: |
-        ./.docker/docker.sh prepare
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+      with:
+        platforms: arm64,arm
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
     - name: Build docker images
       run: ./.docker/docker.sh build
     - name: Test docker images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ Changelog information was migrated to GitHub releases. Check the [releases](http
 
 #### What's Changed
 
-* Resolve current security dependency alerts
-* Update `symfony/routing` and `symfony/http-foundation` to patched `7.4.13` releases
-* Update `@node-minify/core`, `@node-minify/clean-css`, and `@node-minify/terser` to `10.5.0`
-* Refresh npm lock resolution to remove vulnerable `glob` and `brace-expansion` paths
-* Update `minify.js` for the current `@node-minify` API while preserving generated minified assets
+* Restore i18n loading for public pages and fix language change redirects
+* Add repo-managed pre-commit hooks for PHP and frontend validation checks
+* Harden device status payload parsing to preserve uptime and MQTT state across payload variants
+* Add shared JavaScript status helpers with regression coverage for device table rendering
+* Replace broken README GitHub stat badges
+* Update the repo Node.js runtime to `v24`
+* Migrate Docker CI and release jobs to `docker/setup-qemu-action` and `docker/setup-buildx-action`
+* Remove the legacy manual QEMU bootstrap from the Docker build pipeline
 
 ## PUBLISHED
 


### PR DESCRIPTION
## Summary
- migrate Docker CI and release jobs to Buildx and the maintained Docker QEMU setup action
- remove the legacy manual QEMU bootstrap and binary injection from the Docker build path
- refresh the WIP changelog to reflect the latest unreleased work

## Why
The existing Docker workflow was still bootstrapping QEMU by pulling and running multiarch/qemu-user-static directly during prepare. That external Docker Hub dependency was causing intermittent CI failures before any image build started. Moving to docker/setup-qemu-action plus docker/setup-buildx-action makes the workflow match the supported Docker Actions path and removes the brittle manual bootstrap logic.

## Validation
- bash -n .docker/docker.sh
- jq . .github/renovate.json
- ./.docker/docker.sh prepare
- ./.docker/docker.sh build_amd64
- ./.docker/docker.sh test_amd64
- ./.docker/docker.sh build_arm64
- ./.docker/docker.sh test_arm64
