### PR TITLE
Relax mise Python pin

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
-python = '3.14.5'
+python = '3.14'
 pre-commit = '4.6.0'


### PR DESCRIPTION
## Summary
- change the project Python tool spec from an exact patch pin to the `3.14` minor line in `.mise.toml`
- keep `pre-commit` on its existing version

## Why
PR #1537 failed because mise could not install Python 3.14.6 yet during the pre-commit job. Pinning only the `3.14` minor line lets mise resolve the latest available 3.14.x release instead of depending on an immediately recognized patch version.

## Validation
- reviewed the PR #1537 failure log showing `python-build` could not resolve `3.14.6`
- verified the `.mise.toml` diff only changes the Python spec