### PR TITLE
Allow offline device edits with separate friendly names

### DIFF
--- a/tasmoadmin/pages/device_action.php
+++ b/tasmoadmin/pages/device_action.php
@@ -5,7 +5,99 @@ use TasmoAdmin\DeviceFactory;
 use TasmoAdmin\DeviceRepository;
 use TasmoAdmin\Sonoff;
 
-$status = false;
+function normalizeDeviceNames($values): array
+{
+    if (!is_array($values)) {
+        return [];
+    }
+
+    return array_values(
+        array_filter(
+            array_map(static fn ($value): string => trim((string) $value), $values),
+            static fn (string $value): bool => '' !== $value
+        )
+    );
+}
+
+function hasReachableStatus($status): bool
+{
+    return $status instanceof stdClass && !empty((array) $status) && !isset($status->ERROR);
+}
+
+function hasStatusError($status): bool
+{
+    return $status instanceof stdClass && isset($status->ERROR) && '' !== $status->ERROR;
+}
+
+function getFriendlyNamesFromStatus($status): array
+{
+    if (!hasReachableStatus($status) || !isset($status->Status)) {
+        return [];
+    }
+
+    $friendlyNameSource = $status->Status->FriendlyName ?? [];
+    if (!is_array($friendlyNameSource)) {
+        $friendlyNameSource = [$friendlyNameSource];
+    }
+
+    $friendlyNames = normalizeDeviceNames($friendlyNameSource);
+    if ([] === $friendlyNames) {
+        return [];
+    }
+
+    $channelCount = 0;
+    if (isset($status->StatusSTS->POWER)) {
+        $channelCount = 1;
+    } else {
+        for ($i = 1; isset($status->StatusSTS->{'POWER'.$i}); ++$i) {
+            ++$channelCount;
+        }
+    }
+
+    if (0 === $channelCount) {
+        $channelCount = count($friendlyNames);
+    }
+
+    $resolvedFriendlyNames = [];
+    for ($i = 0; $i < max($channelCount, 1); ++$i) {
+        $resolvedFriendlyNames[] = $friendlyNames[$i] ?? trim(($friendlyNames[0] ?? '').' '.($i + 1));
+    }
+
+    return normalizeDeviceNames($resolvedFriendlyNames);
+}
+
+function getDeviceNameState(?Device $device, $status, array $request): array
+{
+    $deviceNames = normalizeDeviceNames($request['device_name'] ?? []);
+    if ([] === $deviceNames && $device instanceof Device) {
+        $deviceNames = normalizeDeviceNames($device->names);
+    }
+
+    $friendlyNames = normalizeDeviceNames($request['device_friendly_name'] ?? []);
+    if ([] === $friendlyNames) {
+        $friendlyNames = getFriendlyNamesFromStatus($status);
+    }
+    if ([] === $friendlyNames && $device instanceof Device) {
+        $friendlyNames = normalizeDeviceNames($device->getFriendlyNames());
+    }
+
+    if ([] === $deviceNames) {
+        $deviceNames = $friendlyNames;
+    }
+    if ([] === $friendlyNames) {
+        $friendlyNames = $deviceNames;
+    }
+
+    $nameCount = max(count($deviceNames), count($friendlyNames), 1);
+    for ($i = 0; $i < $nameCount; ++$i) {
+        $deviceNames[$i] ??= $friendlyNames[$i] ?? '';
+        $friendlyNames[$i] ??= $deviceNames[$i] ?? '';
+    }
+
+    return [array_values($deviceNames), array_values($friendlyNames)];
+}
+
+$status = null;
 $device = null;
 $msg = null;
 
@@ -13,68 +105,95 @@ $Sonoff = $container->get(Sonoff::class);
 $deviceRepository = $container->get(DeviceRepository::class);
 
 if ('edit' == $action) {
-    $device = $Sonoff->getDeviceById($device_id);
+    $device = $deviceRepository->getDeviceById((int) $device_id);
 
-    $status = $Sonoff->getAllStatus($device);
-    if (isset($status->ERROR)) {
-        $msg = __('MSG_DEVICE_NOT_FOUND', 'DEVICE_ACTIONS').'<br/>';
-        $msg .= $status->ERROR.'<br/>';
+    if ($device instanceof Device) {
+        $status = $Sonoff->getAllStatus($device);
+        if (hasStatusError($status)) {
+            $msg = __('MSG_DEVICE_NOT_FOUND', 'DEVICE_ACTIONS').'<br/>';
+            $msg .= $status->ERROR.'<br/>';
+        }
     }
 } elseif ('delete' == $action) {
-    $device[0] = $device_id;
-    $deviceRepository->removeDevice($device[0]);
+    $deviceRepository->removeDevice((int) $device_id);
     $msg = __('MSG_DEVICE_DELETE_DONE', 'DEVICE_ACTIONS');
     $action = 'done';
 }
+
 if (!empty($_POST)) {
     if (isset($_REQUEST['search'])) {
-        if (isset($device_id)) {
-            if (!isset($device)) {
+        $deviceIp = trim((string) ($_REQUEST['device_ip'] ?? ''));
+
+        if ('' === $deviceIp) {
+            $msg = __('ERROR_PLEASE_ENTER_DEVICE_IP', 'DEVICE_ACTIONS');
+        } else {
+            if (!($device instanceof Device) && !empty($_REQUEST['device_id'])) {
+                $device = $deviceRepository->getDeviceById((int) $_REQUEST['device_id']);
+            }
+
+            if (!$device instanceof Device) {
                 $device = DeviceFactory::fakeDevice(
-                    $_REQUEST['device_ip'],
-                    $_REQUEST['device_port'],
-                    $_REQUEST['device_username'],
-                    $_REQUEST['device_password']
+                    $deviceIp,
+                    (int) ($_REQUEST['device_port'] ?? Device::DEFAULT_PORT),
+                    (string) ($_REQUEST['device_username'] ?? ''),
+                    (string) ($_REQUEST['device_password'] ?? '')
                 );
             }
-            $device->ip = $_REQUEST['device_ip'];
-            $device->port = $_REQUEST['device_port'];
-            $device->username = $_REQUEST['device_username'];
-            $device->password = $_REQUEST['device_password'];
+
+            $device->ip = $deviceIp;
+            $device->port = (int) ($_REQUEST['device_port'] ?? Device::DEFAULT_PORT);
+            $device->username = (string) ($_REQUEST['device_username'] ?? '');
+            $device->password = (string) ($_REQUEST['device_password'] ?? '');
 
             $status = $Sonoff->getAllStatus($device);
-            if (isset($status->ERROR)) {
+            if (hasStatusError($status)) {
                 $msg = __('MSG_DEVICE_NOT_FOUND', 'DEVICE_ACTIONS').'<br/>';
                 $msg .= $status->ERROR.'<br/>';
             }
-        } else {
-            $msg = __('ERROR_PLEASE_ENTER_DEVICE_IP', 'DEVICE_ACTIONS');
         }
-    } elseif (!empty($_REQUEST['device_id'])) {// update
+    } elseif (!empty($_REQUEST['device_id'])) {
         $device = DeviceFactory::fromRequest($_REQUEST);
         $deviceRepository->updateDevice($device);
         $msg = __('MSG_DEVICE_EDIT_DONE', 'DEVICE_ACTIONS');
         $action = 'done';
-    } else { // add
+    } else {
         $deviceRepository->addDevice($_REQUEST);
         $msg = __('MSG_DEVICE_ADD_DONE', 'DEVICE_ACTIONS');
         $action = 'done';
     }
 }
 
+[$deviceNames, $friendlyNames] = getDeviceNameState($device, $status, $_REQUEST);
+$showDeviceFields = ('edit' == $action && $device instanceof Device) || hasReachableStatus($status);
+$canSave = ('edit' == $action && $device instanceof Device) || hasReachableStatus($status);
 ?>
 <div class='row justify-content-sm-center'>
 	<div class='col col-12 col-md-8 col-xl-6'>
 		<h2 class='text-sm-center mb-5'>
 			<?php echo $title; ?>
 		</h2>
-		<?php if (isset($status->ERROR) && '' != $status->ERROR) { ?>
+		<?php if (hasStatusError($status)) { ?>
 			<div class="alert alert-danger alert-dismissible fade show mb-5" data-bs-dismiss="alert" role="alert">
 				<p><?php echo __('MSG_DEVICE_NOT_FOUND', 'DEVICE_ACTIONS'); ?></p>
 				<p><?php echo $status->ERROR; ?></p>
 				<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 			</div>
-
+		<?php } elseif (null !== $msg && '' !== $msg && 'done' !== $action) { ?>
+			<div class="alert alert-danger alert-dismissible fade show mb-5" data-bs-dismiss="alert" role="alert">
+				<p><?php echo $msg; ?></p>
+				<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+			</div>
+		<?php } elseif (hasReachableStatus($status) && isset($status->WARNING) && '' !== $status->WARNING) { ?>
+			<div class="alert alert-warning alert-dismissible fade show mb-5" data-bs-dismiss="alert" role="alert">
+				<p><?php echo __('MSG_DEVICE_FOUND', 'DEVICE_ACTIONS'); ?></p>
+				<p><?php echo $status->WARNING; ?></p>
+				<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+			</div>
+		<?php } elseif (hasReachableStatus($status)) { ?>
+			<div class="alert alert-success alert-dismissible fade show my-5" data-bs-dismiss="alert" role="alert">
+				<?php echo __('MSG_DEVICE_FOUND', 'DEVICE_ACTIONS'); ?>
+				<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+			</div>
 		<?php } ?>
 		<?php if ('done' == $action) { ?>
 			<div class="alert alert-success fade show mb-5" role="alert">
@@ -82,7 +201,7 @@ if (!empty($_POST)) {
 					<?php echo $msg; ?>
 				</div>
 				<div class="col col-12 text-start mt-3">
-					<a class="btn btn-secondary  col-12 col-sm-auto" href='<?php echo _BASEURL_; ?>devices'>
+					<a class="btn btn-secondary col-12 col-sm-auto" href='<?php echo _BASEURL_; ?>devices'>
 						<?php echo __('BTN_BACK', 'DEVICE_ACTIONS'); ?>
 					</a>
 				</div>
@@ -97,15 +216,12 @@ if (!empty($_POST)) {
 				</h3>
 			<?php } ?>
 
-
 			<form class='form'
 				  name='save_device'
 				  method='post'
-				  action='<?php echo _BASEURL_; ?>device_action/<?php echo $action; ?><?php echo isset($device->id)
-                      ? '/'.$device->id : ''; ?>'
+				  action='<?php echo _BASEURL_; ?>device_action/<?php echo $action; ?><?php echo isset($device->id) ? '/'.$device->id : ''; ?>'
 			>
 				<input type='hidden' name='device_id' value='<?php echo $device->id ?? ''; ?>'>
-
 
 				<div class="form-row">
 					<div class="form-group col col-12 col-sm-6">
@@ -118,40 +234,35 @@ if (!empty($_POST)) {
 							   id="device_ip"
 							   name='device_ip'
                                placeholder="<?php echo __('PLEASE_ENTER'); ?>"
-                               value='<?php echo isset($device->id) && !isset($_REQUEST['device_ip'])
-                                   ? $device->ip : ($_REQUEST['device_ip']
-                                       ?? ''); ?>'
+                               value='<?php echo isset($device->id) && !isset($_REQUEST['device_ip']) ? $device->ip : ($_REQUEST['device_ip'] ?? ''); ?>'
                                required
 						>
-											<small id="device_ipHelp" class="text-muted">
-						<?php echo __('DEVICE_IP_HELP', 'DEVICE_ACTIONS'); ?>
-					</small>
+						<small id="device_ipHelp" class="text-muted">
+							<?php echo __('DEVICE_IP_HELP', 'DEVICE_ACTIONS'); ?>
+						</small>
 					</div>
                     <div class="form-group col col-12 col-sm-3">
                         <label for="device_port">
                             <?php echo __('DEVICE_PORT', 'DEVICE_ACTIONS'); ?>
                         </label>
                         <input type="text"
-                               autofocus="autofocus"
                                class="form-control"
                                id="device_port"
                                name='device_port'
                                placeholder="<?php echo __('PLEASE_ENTER'); ?>"
-                               value='<?php echo isset($device->port) && !isset($_REQUEST['device_port'])
-                                       ? $device->port : ($_REQUEST['device_port']
-                                               ?? Device::DEFAULT_PORT); ?>'
+                               value='<?php echo isset($device->port) && !isset($_REQUEST['device_port']) ? $device->port : ($_REQUEST['device_port'] ?? Device::DEFAULT_PORT); ?>'
                                required
                         >
-                        					<small id="device_portHelp" class="text-muted">
-						<?php echo __('DEVICE_PORT_HELP', 'DEVICE_ACTIONS'); ?>
-					</small>
+                        <small id="device_portHelp" class="text-muted">
+							<?php echo __('DEVICE_PORT_HELP', 'DEVICE_ACTIONS'); ?>
+						</small>
                     </div>
 					<div class="form-group col col-12 col-sm-3">
 						<label class="d-none d-sm-block">&nbsp;</label>
 						<button type='submit'
 								name='search'
 								value='search'
-								class='btn btn-primary col-12 '
+								class='btn btn-primary col-12'
 						>
 							<?php echo __('BTN_SEARCH_DEVICE', 'DEVICE_ACTIONS'); ?>
 						</button>
@@ -161,10 +272,6 @@ if (!empty($_POST)) {
 					<label for="device_username">
 						<?php echo __('DEVICE_USERNAME', 'DEVICE_ACTIONS'); ?>
 					</label>
-					<!--
-					FAKE to AVOID shitty AUTOFILL
-					fake first pw and nearest input will be detected as username
-					-->
 					<input id="username" style="display: none;" type="text" name="username"/>
 					<input id="password" style="display: none;" type="password" name="password"/>
 
@@ -174,9 +281,7 @@ if (!empty($_POST)) {
 						   class="form-control"
 						   id="device_username"
 						   name='device_username'
-						   value='<?php echo isset($device->id) && !isset($_REQUEST['device_username'])
-                               ? $device->username : ($_REQUEST['device_username']
-                                   ?? 'admin'); ?>'
+						   value='<?php echo isset($device->id) && !isset($_REQUEST['device_username']) ? $device->username : ($_REQUEST['device_username'] ?? 'admin'); ?>'
 					>
 					<small id="device_usernameHelp" class="text-muted">
 						<?php echo __('DEVICE_USERNAME_HELP', 'DEVICE_ACTIONS'); ?>
@@ -192,252 +297,139 @@ if (!empty($_POST)) {
 						   class="form-control"
 						   id="device_password"
 						   name='device_password'
-						   value='<?php echo isset($device->id) && !isset($_REQUEST['device_password'])
-                               ? $device->password : ($_REQUEST['device_password']
-                                   ?? ''); ?>'
+						   value='<?php echo isset($device->id) && !isset($_REQUEST['device_password']) ? $device->password : ($_REQUEST['device_password'] ?? ''); ?>'
 					>
 					<small id="device_passwordHelp" class="text-muted">
 						<?php echo __('DEVICE_PASSWORD_HELP', 'DEVICE_ACTIONS'); ?>
 					</small>
 				</div>
 
-
-				<?php if (isset($status) && !empty($status) && !isset($status->ERROR)) { ?>
-					<?php if (isset($status->WARNING) && !empty($status->WARNING)) { ?>
-						<div class="alert alert-warning alert-dismissible fade show mb-5" data-bs-dismiss="alert"
-							 role="alert"
+				<?php if ($showDeviceFields) { ?>
+					<div class="form-group col">
+						<label for="device_position">
+							<?php echo __('DEVICE_POSITION', 'DEVICE_ACTIONS'); ?>
+						</label>
+						<input type="text"
+							   class="form-control"
+							   id="device_position"
+							   name='device_position'
+							   value='<?php echo isset($device->position) && !isset($_REQUEST['device_position']) ? $device->position : ($_REQUEST['device_position'] ?? ''); ?>'
 						>
-							<p><?php echo __('MSG_DEVICE_FOUND', 'DEVICE_ACTIONS'); ?></p>
-							<p><?php echo $status->WARNING; ?></p>
-							<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-						</div>
-					<?php } else { ?>
-						<div class="alert alert-success alert-dismissible fade show my-5" data-bs-dismiss="alert"
-							 role="alert"
-						>
-							<?php echo __('MSG_DEVICE_FOUND', 'DEVICE_ACTIONS'); ?>
+						<small id="device_positionHelp" class="form-text text-muted">
+							<?php echo __('DEVICE_POSITION_HELP', 'DEVICE_ACTIONS'); ?>
+						</small>
+					</div>
 
-							<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-						</div>
-						<div class="form-group col">
-							<label for="device_position">
-								<?php echo __('DEVICE_POSITION', 'DEVICE_ACTIONS'); ?>
-							</label>
-							<input type="text"
-								   class="form-control"
-								   id="device_position"
-								   name='device_position'
-								   value='<?php echo isset($device->position)
-                                   && !isset($_REQUEST['device_position'])
-                                       ? $device->position : ($_REQUEST['device_position']
-                                           ?? ''); ?>'
-							>
-							<small id="device_positionHelp" class="form-text text-muted">
-								<?php echo __('DEVICE_POSITION_HELP', 'DEVICE_ACTIONS'); ?>
-							</small>
-						</div>
-						<?php if (isset($status->StatusSTS->POWER)) { ?>
-							<?php
-                            $friendlyName = is_array($status->Status->FriendlyName) // array since 5.12.0h
-                                ? $status->Status->FriendlyName[0] : $status->Status->FriendlyName;
-						    ?>
-							<div class="form-row">
-								<div class="form-group col col-12 col-sm-9">
-									<label for="device_name">
-										<?php echo __('LABEL_NAME', 'DEVICE_ACTIONS'); ?>
-									</label>
-									<input type="text"
-										   class="form-control"
-										   id="device_name"
-										   name='device_name[]'
-										   placeholder="<?php echo __('PLEASE_ENTER'); ?>"
-										   value='<?php echo isset($device->id)
-						                       ? $device->names[0] : ($_REQUEST['device_name'][1] ?? $friendlyName); ?>'
-										   required
-									>
-									<small id="device_nameHelp" class="form-text text-muted d-none d-sm-block">
-										&nbsp;
-									</small>
-								</div>
-								<div class="form-group col col-12 col-sm-3">
-									<label class="d-none d-sm-block mb-3">&nbsp;</label>
-									(
-									<a href='#'
-									   class='default-name'
-									><?php echo $friendlyName; ?></a>
-									)
-									<small id="default_nameHelp" class="form-text text-muted">
-										<?php echo __('DEVICE_NAME_TOOLTIP', 'DEVICE_ACTIONS'); ?>
-									</small>
-
-
-								</div>
-							</div>
-						<?php } ?>
-
-
+					<?php foreach ($deviceNames as $index => $deviceName) { ?>
 						<?php
-                        $i = 1;
-					    $power = 'POWER'.$i;
-					    $channelFound = false;
-
-					    while (isset($status->StatusSTS->{$power})) { ?>
-							<?php $channelFound = true;
-					        $friendlyName = is_array($status->Status->FriendlyName) // array since 5.12.0h
-					            ? $status->Status->FriendlyName[$i - 1] : $status->Status->FriendlyName.' '.$i;
-					        ?>
-							<div class="form-row">
-								<div class="form-group col col-12 col-sm-9">
-									<label for="device_name_<?php echo $i; ?>">
-										<?php echo __('LABEL_NAME', 'DEVICE_ACTIONS'); ?><?php echo $i; ?>
-									</label>
-									<input type="text"
-										   class="form-control"
-										   id="device_name_<?php echo $i; ?>"
-										   name='device_name[<?php echo $i; ?>]'
-										   placeholder="<?php echo __('PLEASE_ENTER'); ?>"
-										   value='<?php echo isset($device->names[$i - 1])
-					                       && !empty(
-					                           $device->names[$i - 1]
-					                       )
-					                           ? $device->names[$i - 1] : ($_REQUEST['device_name'][$i] ?? $friendlyName); ?>'
-										   required
-									>
-									<small id="device_name_<?php echo $i; ?>Help"
-										   class="form-text text-muted d-none d-sm-block"
-									>
-										&nbsp;
-									</small>
-								</div>
-								<div class="form-group col col-12 col-sm-3">
-									<label class="d-none d-sm-block mb-3">&nbsp;</label>
-									(
-									<a href='#' title='<?php echo __('DEVICE_NAME_TOOLTIP', 'DEVICE_ACTIONS'); ?>'
-									   class='default-name'
-									><?php echo $friendlyName; ?>
-									</a>
-									)
-									<small id="default_nameHelp" class="form-text text-muted">
-										<?php echo __('DEVICE_NAME_TOOLTIP', 'DEVICE_ACTIONS'); ?>
-									</small>
-
-
-								</div>
-							</div>
-
-
-							<?php
-
-                            ++$i;
-					        $power = 'POWER'.$i;
-					        ?>
-
-						<?php } ?>
-
-						<?php if (!isset($status->StatusSTS->POWER) && !$channelFound) {
-						    // no channel found?>
-							<?php
-						    $friendlyName = is_array($status->Status->FriendlyName) // array since 5.12.0h
-						        ? $status->Status->FriendlyName[0] : $status->Status->FriendlyName;
-						    ?>
-							<div class="form-row">
-								<div class="form-group col col-12 col-sm-9">
-									<label for="device_name">
-										<?php echo __('LABEL_NAME', 'DEVICE_ACTIONS'); ?>
-									</label>
-									<input type="text"
-										   class="form-control"
-										   id="device_name"
-										   name='device_name[]'
-										   placeholder="<?php echo __('PLEASE_ENTER'); ?>"
-										   value='<?php echo isset($device->id)
-						                       ? $device->names[0] : ($_REQUEST['device_name'][1] ?? $friendlyName); ?>'
-										   required
-									>
-									<small id="device_nameHelp" class="form-text text-muted d-none d-sm-block">
-										&nbsp;
-									</small>
-								</div>
-								<div class="form-group col col-12 col-sm-3">
-									<label class="d-none d-sm-block mb-3">&nbsp;</label>
-									(
-									<a href='#'
-									   class='default-name'
-									><?php echo $friendlyName; ?></a>
-									)
-									<small id="default_nameHelp" class="form-text text-muted">
-										<?php echo __('DEVICE_NAME_TOOLTIP', 'DEVICE_ACTIONS'); ?>
-									</small>
-
-
-								</div>
-							</div>
-						<?php } ?>
-
+                        $friendlyName = $friendlyNames[$index] ?? '';
+					    $nameLabel = __('LABEL_NAME', 'DEVICE_ACTIONS').(count($deviceNames) > 1 ? $index + 1 : '');
+					    ?>
 						<div class="form-row">
-							<div class="form-group col col-12 col-sm-3">
-								<div class="form-check mb-5">
-
-									<input type='hidden' name='device_all_off' value='0'>
-									<input class="form-check-input"
-										   type="checkbox"
-										   value="1"
-										   id="device_all_off"
-										   name='device_all_off' <?php echo $device->deviceAllOff ? 'checked="checked"' : ''; ?>>
-									<label class="form-check-label" for="device_all_off">
-										<?php echo __('LABEL_ALL_OFF', 'DEVICE_ACTIONS'); ?>
-									</label>
-								</div>
+							<div class="form-group col col-12 col-sm-7">
+								<label for="device_name_<?php echo $index; ?>">
+									<?php echo $nameLabel; ?>
+								</label>
+								<input type="text"
+									   class="form-control tasmoadmin-name-input"
+									   id="device_name_<?php echo $index; ?>"
+									   name='device_name[<?php echo $index; ?>]'
+									   placeholder="<?php echo __('PLEASE_ENTER'); ?>"
+									   value='<?php echo htmlspecialchars($deviceName, ENT_QUOTES); ?>'
+									   required
+								>
+								<small class="form-text text-muted d-none d-sm-block">
+									&nbsp;
+								</small>
 							</div>
-							<div class="form-group col col-12 col-sm-3">
-								<div class="form-check mb-5">
-
-									<input type='hidden' name='device_protect_on' value='0'>
-									<input class="form-check-input"
-										   type="checkbox"
-										   value="1"
-										   id="device_protect_on"
-										   name='device_protect_on' <?php echo $device->deviceProtectionOn ? 'checked="checked"' : ''; ?>>
-									<label class="form-check-label" for="device_protect_on">
-										<?php echo __('LABEL_PROTECT_ON', 'DEVICE_ACTIONS'); ?>
-									</label>
+							<div class="form-group col col-12 col-sm-5">
+								<label for="device_friendly_name_<?php echo $index; ?>">
+									<?php echo __('CONFIG_FRIENDLYNAME', 'DEVICE_CONFIG'); ?>
+								</label>
+								<div class="input-group">
+									<input type="text"
+										   class="form-control"
+										   id="device_friendly_name_<?php echo $index; ?>"
+										   value='<?php echo htmlspecialchars($friendlyName, ENT_QUOTES); ?>'
+										   readonly
+									>
+									<input type='hidden'
+										   name='device_friendly_name[<?php echo $index; ?>]'
+										   value='<?php echo htmlspecialchars($friendlyName, ENT_QUOTES); ?>'
+									>
+									<button type="button"
+											class="btn btn-outline-secondary default-name"
+											data-default-name="<?php echo htmlspecialchars($friendlyName, ENT_QUOTES); ?>"
+									>
+										<?php echo __('DEVICE_NAME_TOOLTIP', 'DEVICE_ACTIONS'); ?>
+									</button>
 								</div>
+								<small class="form-text text-muted">
+									<?php echo __('DEVICE_NAME_TOOLTIP', 'DEVICE_ACTIONS'); ?>
+								</small>
 							</div>
-							<div class="form-group col col-12 col-sm-3">
-								<div class="form-check mb-5">
-
-									<input type='hidden' name='device_protect_off' value='0'>
-									<input class="form-check-input"
-										   type="checkbox"
-										   value="1"
-										   id="device_protect_off"
-										   name='device_protect_off'  <?php echo $device->deviceProtectionOff ? 'checked="checked"' : ''; ?>>
-									<label class="form-check-label" for="device_protect_off">
-										<?php echo __('LABEL_PROTECT_OFF', 'DEVICE_ACTIONS'); ?>
-									</label>
-								</div>
-							</div>
-                            <div class="form-group col col-12 col-sm-3">
-                                <div class="form-check mb-5">
-
-                                    <input type='hidden' name='is_updatable' value='0'>
-                                    <input class="form-check-input"
-                                           type="checkbox"
-                                           value="1"
-                                           id="is_updatable"
-                                           name='is_updatable' <?php echo $device->isUpdatable ? 'checked="checked"' : ''; ?>>
-                                    <label class="form-check-label" for="is_updatable">
-                                        <?php echo __('LABEL_IS_UPDATABLE', 'DEVICE_ACTIONS'); ?>
-                                    </label>
-                                </div>
-                            </div>
 						</div>
 					<?php } ?>
 
+					<div class="form-row">
+						<div class="form-group col col-12 col-sm-3">
+							<div class="form-check mb-5">
+								<input type='hidden' name='device_all_off' value='0'>
+								<input class="form-check-input"
+									   type="checkbox"
+									   value="1"
+									   id="device_all_off"
+									   name='device_all_off' <?php echo $device->deviceAllOff ? 'checked="checked"' : ''; ?>>
+								<label class="form-check-label" for="device_all_off">
+									<?php echo __('LABEL_ALL_OFF', 'DEVICE_ACTIONS'); ?>
+								</label>
+							</div>
+						</div>
+						<div class="form-group col col-12 col-sm-3">
+							<div class="form-check mb-5">
+								<input type='hidden' name='device_protect_on' value='0'>
+								<input class="form-check-input"
+									   type="checkbox"
+									   value="1"
+									   id="device_protect_on"
+									   name='device_protect_on' <?php echo $device->deviceProtectionOn ? 'checked="checked"' : ''; ?>>
+								<label class="form-check-label" for="device_protect_on">
+									<?php echo __('LABEL_PROTECT_ON', 'DEVICE_ACTIONS'); ?>
+								</label>
+							</div>
+						</div>
+						<div class="form-group col col-12 col-sm-3">
+							<div class="form-check mb-5">
+								<input type='hidden' name='device_protect_off' value='0'>
+								<input class="form-check-input"
+									   type="checkbox"
+									   value="1"
+									   id="device_protect_off"
+									   name='device_protect_off' <?php echo $device->deviceProtectionOff ? 'checked="checked"' : ''; ?>>
+								<label class="form-check-label" for="device_protect_off">
+									<?php echo __('LABEL_PROTECT_OFF', 'DEVICE_ACTIONS'); ?>
+								</label>
+							</div>
+						</div>
+                        <div class="form-group col col-12 col-sm-3">
+                            <div class="form-check mb-5">
+                                <input type='hidden' name='is_updatable' value='0'>
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       value="1"
+                                       id="is_updatable"
+                                       name='is_updatable' <?php echo $device->isUpdatable ? 'checked="checked"' : ''; ?>>
+                                <label class="form-check-label" for="is_updatable">
+                                    <?php echo __('LABEL_IS_UPDATABLE', 'DEVICE_ACTIONS'); ?>
+                                </label>
+                            </div>
+                        </div>
+					</div>
 				<?php } ?>
+
 				<div class="row">
 					<div class="col col-12 col-sm-6 text-start">
-						<a class="btn btn-secondary  col-12 col-sm-auto" href='<?php echo _BASEURL_; ?>devices'>
+						<a class="btn btn-secondary col-12 col-sm-auto" href='<?php echo _BASEURL_; ?>devices'>
 							<?php echo __('BTN_BACK', 'DEVICE_ACTIONS'); ?>
 						</a>
 					</div>
@@ -446,7 +438,7 @@ if (!empty($_POST)) {
 								name='submit'
 								value='<?php echo isset($device->id) ? 'edit' : 'add'; ?>'
 								class='btn btn-primary col-12 col-sm-auto'
-							<?php if (!isset($status) || empty($status) || isset($status->ERROR)) { ?>
+							<?php if (!$canSave) { ?>
 								disabled
 							<?php } ?>
 						>
@@ -454,13 +446,8 @@ if (!empty($_POST)) {
 						</button>
 					</div>
 				</div>
-
-				</table>
 			</form>
-
-
 		<?php } ?>
-
 	</div>
 </div>
 <script>
@@ -469,7 +456,10 @@ if (!empty($_POST)) {
         $(".default-name").on("click", function (e)
         {
             e.preventDefault();
-            $(this).parent().parent().find("input").val($(this).html().trim());
+            $(this)
+                .closest(".form-row")
+                .find(".tasmoadmin-name-input")
+                .val($(this).data("default-name").trim());
         });
     });
 </script>

--- a/tasmoadmin/src/Device.php
+++ b/tasmoadmin/src/Device.php
@@ -9,6 +9,7 @@ class Device
 
     public ?int $id;
     public array $names;
+    public array $friendlyNames;
     public string $ip;
     public int $port;
     public string $username;
@@ -34,10 +35,12 @@ class Device
         bool $deviceProtectionOff = false,
         array $keywords = [],
         bool $isUpdatable = true,
-        int $port = self::DEFAULT_PORT
+        int $port = self::DEFAULT_PORT,
+        array $friendlyNames = []
     ) {
         $this->id = $id;
         $this->names = $names;
+        $this->friendlyNames = !empty($friendlyNames) ? $friendlyNames : $names;
         $this->ip = $ip;
         $this->port = $port;
         $this->username = $username;
@@ -59,6 +62,11 @@ class Device
     public function getName(): string
     {
         return implode('-', $this->names);
+    }
+
+    public function getFriendlyNames(): array
+    {
+        return !empty($this->friendlyNames) ? $this->friendlyNames : $this->names;
     }
 
     public function getBackupName(): string

--- a/tasmoadmin/src/DeviceFactory.php
+++ b/tasmoadmin/src/DeviceFactory.php
@@ -18,9 +18,11 @@ class DeviceFactory
 
     public static function fromRequest(array $request): Device
     {
+        $deviceNames = array_values($request['device_name'] ?? []);
+        $friendlyNames = array_values($request['device_friendly_name'] ?? $deviceNames);
         $device = [];
         $device[0] = $request['device_id'];
-        $device[1] = implode('|', $request['device_name']);
+        $device[1] = implode('|', $deviceNames);
         $device[2] = $request['device_ip'];
         $device[3] = $request['device_username'];
         $device[4] = $request['device_password'];
@@ -31,6 +33,7 @@ class DeviceFactory
         $device[9] = $request['device_protect_off'] ?? false;
         $device[10] = $request['is_updatable'] ?? true;
         $device[11] = $request['device_port'] ?? Device::DEFAULT_PORT;
+        $device[12] = implode('|', $friendlyNames);
 
         return self::fromArray($device);
     }
@@ -41,10 +44,12 @@ class DeviceFactory
             return null;
         }
 
-        $array[1] = explode('|', $array[1] ?? '');
+        $array[1] = array_values(array_filter(explode('|', $array[1] ?? ''), static fn ($value) => '' !== $value));
+        $array[12] = array_values(array_filter(explode('|', $array[12] ?? ''), static fn ($value) => '' !== $value));
 
         $id = $array[0] ?? null;
         $names = $array[1];
+        $friendlyNames = !empty($array[12]) ? $array[12] : $names;
         $ip = $array[2] ?? false;
         $username = $array[3] ?? false;
         $password = $array[4] ?? false;
@@ -76,6 +81,7 @@ class DeviceFactory
             $keywords,
             (bool) $is_updatable,
             (int) $port,
+            $friendlyNames,
         );
     }
 }

--- a/tasmoadmin/src/DeviceRepository.php
+++ b/tasmoadmin/src/DeviceRepository.php
@@ -19,6 +19,7 @@ class DeviceRepository
     private array $allowedUpdateFields = [
         'id',
         'names',
+        'friendlyNames',
         'position',
         'ip',
         'username',
@@ -64,6 +65,7 @@ class DeviceRepository
             $deviceHolder[9] = $device['device_protect_off'] ?? 0;
             $deviceHolder[10] = $device['is_updatable'] ?? 1;
             $deviceHolder[11] = $device['device_port'] ?? Device::DEFAULT_PORT;
+            $deviceHolder[12] = implode('|', $device['device_friendly_name'] ?? ($device['device_name'] ?? []));
 
             fputcsv($handle, $deviceHolder, escape: self::CSV_ESCAPE);
         }
@@ -193,6 +195,7 @@ class DeviceRepository
         $deviceArr[9] = !empty($device->deviceProtectionOff) ? $device->deviceProtectionOff : 0;
         $deviceArr[10] = !empty($device->isUpdatable) ? $device->isUpdatable : 0;
         $deviceArr[11] = $device->port;
+        $deviceArr[12] = implode('|', !empty($device->friendlyNames) ? $device->friendlyNames : $device->names);
 
         foreach ($deviceArr as $key => $field) {
             $deviceArr[$key] = trim($field);

--- a/tasmoadmin/tests/DeviceFactoryTest.php
+++ b/tasmoadmin/tests/DeviceFactoryTest.php
@@ -14,6 +14,7 @@ class DeviceFactoryTest extends TestCase
         self::assertEquals('user', $device->username);
         self::assertEquals('pass', $device->password);
         self::assertEquals(5000, $device->port);
+        self::assertSame([], $device->friendlyNames);
     }
 
     public function testFromArrayEmpty(): void
@@ -43,6 +44,7 @@ class DeviceFactoryTest extends TestCase
         self::assertEquals(0, $device->deviceProtectionOff);
         self::assertEquals(1, $device->deviceAllOff);
         self::assertTrue($device->isUpdatable);
+        self::assertEquals(['socket-1'], $device->friendlyNames);
     }
 
     public function testFromArrayComplete(): void
@@ -60,6 +62,7 @@ class DeviceFactoryTest extends TestCase
             1,
             false,
             5000,
+            'friendly-1',
         ]);
 
         self::assertEquals(1, $device->position);
@@ -74,6 +77,7 @@ class DeviceFactoryTest extends TestCase
         self::assertEquals(0, $device->deviceAllOff);
         self::assertFalse($device->isUpdatable);
         self::assertEquals(5000, $device->port);
+        self::assertEquals(['friendly-1'], $device->friendlyNames);
     }
 
     public function testFromRequest(): void
@@ -85,12 +89,14 @@ class DeviceFactoryTest extends TestCase
             'device_username' => 'user',
             'device_password' => 'pass',
             'device_position' => '',
+            'device_friendly_name' => ['webui-socket-1'],
         ];
 
         $device = DeviceFactory::fromRequest($request);
         self::assertEquals(1, $device->id);
         self::assertEquals(['socket-1'], $device->names);
         self::assertEquals('socket-1', $device->getName());
+        self::assertEquals(['webui-socket-1'], $device->friendlyNames);
         self::assertEquals('192.168.1.1', $device->ip);
         self::assertEquals('user', $device->username);
         self::assertEquals('pass', $device->password);
@@ -106,11 +112,13 @@ class DeviceFactoryTest extends TestCase
             'device_username' => 'user',
             'device_password' => 'pass',
             'device_position' => '',
+            'device_friendly_name' => ['webui-socket-1', 'webui-socket-2'],
         ];
 
         $device = DeviceFactory::fromRequest($request);
         self::assertEquals(1, $device->id);
         self::assertEquals(['socket-1', 'socket-2'], $device->names);
+        self::assertEquals(['webui-socket-1', 'webui-socket-2'], $device->friendlyNames);
         self::assertEquals('socket-1-socket-2', $device->getName());
         self::assertEquals('192.168.1.1', $device->ip);
         self::assertEquals('user', $device->username);

--- a/tasmoadmin/tests/DeviceRepositoryTest.php
+++ b/tasmoadmin/tests/DeviceRepositoryTest.php
@@ -48,6 +48,7 @@ class DeviceRepositoryTest extends TestCase
         self::assertCount(1, $repo->getDevices());
         $device = $repo->getDevices()[0];
         self::assertEquals(['socket-1'], $device->names);
+        self::assertEquals(['socket-1'], $device->friendlyNames);
     }
 
     public function testAddDeviceWithEscapeCharacter(): void
@@ -124,6 +125,7 @@ class DeviceRepositoryTest extends TestCase
         self::assertCount(1, $repo->getDevices());
         $device = $repo->getDevices()[0];
         self::assertEquals(['socket-1'], $device->names);
+        self::assertEquals(['socket-1'], $device->friendlyNames);
         self::assertTrue($device->isUpdatable);
         self::assertEquals(80, $device->port);
     }
@@ -141,6 +143,7 @@ class DeviceRepositoryTest extends TestCase
         self::assertEquals('bulb_1', $device->img);
         self::assertEquals(2, $device->position);
         self::assertEquals(5000, $device->port);
+        self::assertEquals(['socket-1'], $device->friendlyNames);
     }
 
     public function testGetDeviceByIdInvalidId(): void
@@ -256,6 +259,35 @@ class DeviceRepositoryTest extends TestCase
         $repo->setDeviceValue(1, 'names', ['socket-2']);
         $device = $repo->getDeviceById(1);
         self::assertEquals(['socket-2'], $device->names);
+    }
+
+    public function testSetDeviceValueFriendlyNames(): void
+    {
+        $repo = $this->getVirtualRepo();
+        $repo->addDevices([['device_name' => ['socket-1']]], 'user', 'pass');
+
+        $repo->setDeviceValue(1, 'friendlyNames', ['webui-socket-1']);
+
+        $device = $repo->getDeviceById(1);
+        self::assertEquals(['webui-socket-1'], $device->friendlyNames);
+    }
+
+    public function testAddDevicesStoresFriendlyNamesSeparately(): void
+    {
+        $repo = $this->getVirtualRepo();
+        $repo->addDevices(
+            [[
+                'device_name' => ['office-lamp'],
+                'device_friendly_name' => ['lamp-webui'],
+                'device_ip' => '127.0.0.1',
+            ]],
+            'user',
+            'pass'
+        );
+
+        $device = $repo->getDeviceById(1);
+        self::assertSame(['office-lamp'], $device->names);
+        self::assertSame(['lamp-webui'], $device->friendlyNames);
     }
 
     public function testSetDeviceValuePasswordNeverWritesPlaintextBackToDisk(): void

--- a/tasmoadmin/tests/DeviceTest.php
+++ b/tasmoadmin/tests/DeviceTest.php
@@ -91,4 +91,33 @@ class DeviceTest extends TestCase
             ],
         ];
     }
+
+    public function testGetFriendlyNamesFallsBackToAdminNames(): void
+    {
+        $device = new Device(1, ['socket-1'], '192.168.1.1', '', '', 'img', 1, false, false, false, []);
+
+        $this->assertSame(['socket-1'], $device->getFriendlyNames());
+    }
+
+    public function testGetFriendlyNamesUsesStoredFriendlyNames(): void
+    {
+        $device = new Device(
+            1,
+            ['office-lamp'],
+            '192.168.1.1',
+            '',
+            '',
+            'img',
+            1,
+            false,
+            false,
+            false,
+            [],
+            true,
+            80,
+            ['lamp-webui']
+        );
+
+        $this->assertSame(['lamp-webui'], $device->getFriendlyNames());
+    }
 }


### PR DESCRIPTION
## Summary
- allow the device edit page to stay usable when the target device is offline or unreachable
- persist remembered device Web UI friendly names separately from TasmoAdmin-local names
- update the edit form so TasmoAdmin names and device FriendlyName values are shown as separate fields, with an explicit adopt action instead of conflating them

## Why
This milestone slice covers two related device-editing issues:
- `#359` requires saved devices to remain editable even when the live status request fails
- `#1128` requires the TasmoAdmin-facing device name and the generated Web UI link target/name context to diverge cleanly

The previous edit flow gated the full form on a successful `status 0` request and only stored one name array, so offline edits were blocked and TasmoAdmin-local naming could not be represented separately from remembered device Web UI names.

## Impact
Operators can now update saved device metadata even while a device is offline, and TasmoAdmin retains separate Web UI naming context while continuing to use TasmoAdmin-local names for display and persistence behavior.

## Validation
- `ddev exec ./vendor/bin/phpunit --display-deprecations`
- `ddev exec ./vendor/bin/phpstan`

## Issues
- Closes #359
- Closes #1128
