### PR TITLE
Add cache clear control to settings

### DIFF
--- a/tasmoadmin/lang/de/lang.ini
+++ b/tasmoadmin/lang/de/lang.ini
@@ -120,6 +120,18 @@ CONFIG_UPDATE_BE_CHECK = "Backend-Überprüfung"
 ; CONFIG_FORCE_UPGRADE_HELP = "When set force upgrade irrespective of the device current version"
 ; CONFIG_UPDATE_NEWER_ONLY = "Update newer only"
 ; CONFIG_UPDATE_NEWER_ONLY_HELP = "Only upgrade if firmware version is newer than already installed"
+CONFIG_ADVANCED = "Erweitert"
+CONFIG_CONNECT_TIMEOUT = "Verbindungs-Timeout"
+CONFIG_CONNECT_TIMEOUT_HELP = "Zeitlimit in Sekunden beim Verbinden mit einem Modul"
+CONFIG_TIMEOUT = "Timeout"
+CONFIG_TIMEOUT_HELP = "Zeitlimit in Sekunden beim Abrufen von Daten von einem Modul"
+CONFIG_REQUEST_CONCURRENCY = "Parallele Anfragen"
+CONFIG_REQUEST_CONCURRENCY_HELP = "Anzahl der gleichzeitig gestarteten Anfragen"
+CONFIG_MAINTENANCE_TITLE = "Wartung"
+CONFIG_CACHE_CLEAR_SCOPE = "Löscht nur temporäre Sitzungs- und Sprachcache-Dateien aus dem tmp-Verzeichnis."
+CONFIG_CACHE_CLEAR_SAFE = "Gespeicherte Einstellungen, Module und Zugangsdaten bleiben unverändert."
+BTN_CLEAR_CACHE = "Temporären Cache löschen"
+MSG_CACHE_CLEARED = "Temporärer Cache gelöscht"
 
 
 [DEVICE_ACTIONS]

--- a/tasmoadmin/lang/en/lang.ini
+++ b/tasmoadmin/lang/en/lang.ini
@@ -127,6 +127,11 @@ CONFIG_TIMEOUT_HELP = "The timeout in seconds, when fetching data from a device"
 CONFIG_ADVANCED = "Advanced"
 CONFIG_REQUEST_CONCURRENCY = "Request concurrency"
 CONFIG_REQUEST_CONCURRENCY_HELP = "The number of requests to concurrently dispatch"
+CONFIG_MAINTENANCE_TITLE = "Maintenance"
+CONFIG_CACHE_CLEAR_SCOPE = "Clear temporary session and language cache files from the tmp directory."
+CONFIG_CACHE_CLEAR_SAFE = "Saved settings, devices, and credentials are left untouched."
+BTN_CLEAR_CACHE = "Clear temporary cache"
+MSG_CACHE_CLEARED = "Temporary cache cleared"
 
 
 [DEVICE_ACTIONS]

--- a/tasmoadmin/pages/actions.php
+++ b/tasmoadmin/pages/actions.php
@@ -3,6 +3,7 @@
 use TasmoAdmin\Backup\BackupHelper;
 use TasmoAdmin\DevicePasswordKeyProvider;
 use TasmoAdmin\DeviceRepository;
+use TasmoAdmin\Helper\CacheCleanupHelper;
 use TasmoAdmin\Helper\FirmwareFolderHelper;
 use TasmoAdmin\Helper\SupportedLanguageHelper;
 use TasmoAdmin\Sonoff;
@@ -76,22 +77,8 @@ if (isset($_GET['downloadBackup'])) {
 if (isset($_GET['clean'])) {
     $what = explode('_', $_GET['clean']);
 
-    if (in_array('sessions', $what)) {
-        $files = glob(_TMPDIR_.'/sessions/*'); // get all file names
-        foreach ($files as $file) { // iterate files
-            if (is_file($file) && false === strpos($file, '.empty')) {
-                @unlink($file);
-            } // delete file
-        }
-    }
-
-    if (in_array('i18n', $what)) {
-        $files = glob(_TMPDIR_.'/cache/i18n/*'); // get all file names present in folder
-        foreach ($files as $file) { // iterate files
-            if (is_file($file)) {
-                @unlink($file);
-            }
-        }
+    if (array_intersect(['sessions', 'i18n'], $what)) {
+        CacheCleanupHelper::cleanTargets(_TMPDIR_, $what);
     }
 
     if (in_array('firmwares', $what)) {

--- a/tasmoadmin/pages/elements/cache_cleanup_panel.php
+++ b/tasmoadmin/pages/elements/cache_cleanup_panel.php
@@ -1,0 +1,16 @@
+<div class="row mt-5">
+    <div class="col col-12">
+        <div class="card">
+            <div class="card-body">
+                <h2 class="h4 mb-3"><?php echo __('CONFIG_MAINTENANCE_TITLE', 'USER_CONFIG'); ?></h2>
+                <p class="mb-2"><?php echo __('CONFIG_CACHE_CLEAR_SCOPE', 'USER_CONFIG'); ?></p>
+                <p class="text-body-secondary mb-4"><?php echo __('CONFIG_CACHE_CLEAR_SAFE', 'USER_CONFIG'); ?></p>
+                <form method="post" class="mb-0">
+                    <button type="submit" class="btn btn-outline-secondary" name="clean_temp_cache" value="1">
+                        <?php echo __('BTN_CLEAR_CACHE', 'USER_CONFIG'); ?>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tasmoadmin/pages/site_config.php
+++ b/tasmoadmin/pages/site_config.php
@@ -2,6 +2,7 @@
 
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use Symfony\Component\BrowserKit\HttpBrowser;
+use TasmoAdmin\Helper\CacheCleanupHelper;
 use TasmoAdmin\Helper\GuzzleFactory;
 use TasmoAdmin\Helper\LoginHelper;
 use TasmoAdmin\Helper\TasmotaHelper;
@@ -10,7 +11,10 @@ use TasmoAdmin\Helper\TasmotaOtaScraper;
 $msg = false;
 $settings = [];
 
-if (isset($_POST['save'])) {
+if (isset($_POST['clean_temp_cache'])) {
+    CacheCleanupHelper::cleanTargets(_TMPDIR_, ['sessions', 'i18n']);
+    $msg = __('MSG_CACHE_CLEARED', 'USER_CONFIG');
+} elseif (isset($_POST['save'])) {
     $settings = $_POST;
     unset($settings['save']);
 
@@ -476,5 +480,6 @@ $autoFirmwareChannels = ['stable', 'dev'];
 				</div>
 			</div>
 		</form>
+        <?php include __DIR__.'/elements/cache_cleanup_panel.php'; ?>
 	</div>
 </div>

--- a/tasmoadmin/src/Helper/CacheCleanupHelper.php
+++ b/tasmoadmin/src/Helper/CacheCleanupHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace TasmoAdmin\Helper;
+
+class CacheCleanupHelper
+{
+    /**
+     * @param list<string> $targets
+     *
+     * @return array{sessions:int,i18n:int}
+     */
+    public static function cleanTargets(string $tmpDir, array $targets): array
+    {
+        $tmpDir = rtrim($tmpDir, '/');
+        $result = [
+            'sessions' => 0,
+            'i18n' => 0,
+        ];
+
+        if (in_array('sessions', $targets, true)) {
+            $result['sessions'] = self::cleanDirectory($tmpDir.'/sessions', true);
+        }
+
+        if (in_array('i18n', $targets, true)) {
+            $result['i18n'] = self::cleanDirectory($tmpDir.'/cache/i18n', false);
+        }
+
+        return $result;
+    }
+
+    private static function cleanDirectory(string $directory, bool $preserveEmptyFile): int
+    {
+        $removed = 0;
+
+        if (!is_dir($directory)) {
+            return 0;
+        }
+
+        $files = scandir($directory);
+
+        if (false === $files) {
+            return 0;
+        }
+
+        foreach ($files as $fileName) {
+            if ('.' === $fileName || '..' === $fileName) {
+                continue;
+            }
+
+            $file = $directory.'/'.$fileName;
+            if (!is_file($file)) {
+                continue;
+            }
+
+            if ($preserveEmptyFile && '.empty' === $fileName) {
+                continue;
+            }
+
+            if (@unlink($file)) {
+                ++$removed;
+            }
+        }
+
+        return $removed;
+    }
+}

--- a/tasmoadmin/tests/Helper/CacheCleanupHelperTest.php
+++ b/tasmoadmin/tests/Helper/CacheCleanupHelperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\TasmoAdmin\Helper;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use TasmoAdmin\Helper\CacheCleanupHelper;
+
+class CacheCleanupHelperTest extends TestCase
+{
+    public function testCleanTargetsRemovesTemporarySessionAndLanguageCacheFiles(): void
+    {
+        $filesystem = vfsStream::setup('tmp', null, [
+            'sessions' => [
+                'session-one' => 'abc',
+                '.empty' => '',
+            ],
+            'cache' => [
+                'i18n' => [
+                    'json_i18n_en.cache.json' => '{}',
+                    'json_i18n_de.cache.json' => '{}',
+                ],
+            ],
+            'keep' => [
+                'readme.txt' => 'keep',
+            ],
+        ]);
+
+        $result = CacheCleanupHelper::cleanTargets($filesystem->url(), ['sessions', 'i18n']);
+
+        self::assertSame(['sessions' => 1, 'i18n' => 2], $result);
+        self::assertFileDoesNotExist($filesystem->url().'/sessions/session-one');
+        self::assertFileExists($filesystem->url().'/sessions/.empty');
+        self::assertFileDoesNotExist($filesystem->url().'/cache/i18n/json_i18n_en.cache.json');
+        self::assertFileDoesNotExist($filesystem->url().'/cache/i18n/json_i18n_de.cache.json');
+        self::assertFileExists($filesystem->url().'/keep/readme.txt');
+    }
+
+    public function testCleanTargetsHandlesMissingFolders(): void
+    {
+        $filesystem = vfsStream::setup('tmp');
+
+        $result = CacheCleanupHelper::cleanTargets($filesystem->url(), ['sessions', 'i18n']);
+
+        self::assertSame(['sessions' => 0, 'i18n' => 0], $result);
+    }
+}

--- a/tasmoadmin/tests/Page/CacheCleanupPanelTest.php
+++ b/tasmoadmin/tests/Page/CacheCleanupPanelTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\TasmoAdmin\Page;
+
+use PHPUnit\Framework\TestCase;
+
+class CacheCleanupPanelTest extends TestCase
+{
+    public function testPanelRendersSafeMaintenanceCopyAndButton(): void
+    {
+        ob_start();
+
+        include __DIR__.'/../../pages/elements/cache_cleanup_panel.php';
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('USER_CONFIG_CONFIG_MAINTENANCE_TITLE:', $output);
+        self::assertStringContainsString('USER_CONFIG_CONFIG_CACHE_CLEAR_SCOPE:', $output);
+        self::assertStringContainsString('USER_CONFIG_CONFIG_CACHE_CLEAR_SAFE:', $output);
+        self::assertStringContainsString('name="clean_temp_cache"', $output);
+        self::assertStringContainsString('USER_CONFIG_BTN_CLEAR_CACHE:', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add a maintenance panel to `site_config` for clearing temporary session and i18n cache files
- keep the UI scope intentionally safe by leaving device, config, and credential data untouched
- reuse the same cleanup helper from the legacy `actions.php?clean=` path and cover the helper plus panel rendering with PHPUnit

## Why
Issue #686 asks for a manual cache clear action from the UI when temporary cache files become inconsistent. The existing backend cleanup path was only available through direct maintenance endpoints, and some of those options are broader than the issue requires.

## User impact
- administrators can clear temporary cache state directly from the settings page
- the page explains that only temporary session and language cache files are removed
- destructive cleanup paths remain out of the new UI

## Checks
- `ddev exec ./vendor/bin/phpunit tests/Helper/CacheCleanupHelperTest.php tests/Page/CacheCleanupPanelTest.php`
- `ddev exec ./vendor/bin/phpstan analyse`
- `npm run prettier:check`
- pre-commit hook suite during `git commit` (`php-cs-fixer`, `phpstan`, full `phpunit`)
- manual: verified `site_config` renders the new Maintenance panel in Chrome DevTools and that posting `clean_temp_cache=1` removes seeded files from `/tmp/tasmoadmin/sessions` and `/tmp/tasmoadmin/cache/i18n`

## Issues
- closes #686
