### PR TITLE
Prefer dist installs for Composer deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         php-version: '8.5'
     - name: Install dependencies
-      run: composer install -d tasmoadmin/
+      run: composer install --prefer-dist -d tasmoadmin/
     - name: Run PHPStan
       run: |
         cd tasmoadmin
@@ -49,7 +49,7 @@ jobs:
         with:
           php-version: '8.5'
       - name: Install dependencies
-        run: composer install -d tasmoadmin/
+        run: composer install --prefer-dist -d tasmoadmin/
       - name: Run php-cs-fixer
         run: |
           cd tasmoadmin
@@ -67,7 +67,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
     - name: Install dependencies
-      run: composer install -d tasmoadmin/
+      run: composer install --prefer-dist -d tasmoadmin/
     - name: Run tests
       run: |
         cd tasmoadmin

--- a/Makefile
+++ b/Makefile
@@ -31,19 +31,19 @@ docker-publish: docker-tag
 package: clean
 	mkdir _releases
 	mkdir _tmp
-	composer install --no-dev -o -d tasmoadmin
+	composer install --prefer-dist --no-dev -o -d tasmoadmin
 	cd tasmoadmin; npm ci; npm run build; rm -rf node_modules
 	tar -zcf ./_releases/tasmoadmin_${BUILD_VERSION}.tar.gz tasmoadmin
 	zip -q -r ./_releases/tasmoadmin_${BUILD_VERSION}.zip tasmoadmin
 
 quality: clean
-	composer install -d tasmoadmin
+	composer install --prefer-dist -d tasmoadmin
 	cd tasmoadmin; ./vendor/bin/php-cs-fixer fix
 	cd tasmoadmin; ./vendor/bin/phpunit
 	cd tasmoadmin; php -d memory_limit=4G ./vendor/bin/phpstan
 
 dev:
 	./.docker/docker.sh prepare
-	composer install -d tasmoadmin
+	composer install --prefer-dist -d tasmoadmin
 	cd tasmoadmin; npm ci; npm run build
 	docker-compose build  --no-cache && docker-compose up


### PR DESCRIPTION
## Summary
- add `--prefer-dist` to Composer installs in GitHub Actions PHP jobs
- add `--prefer-dist` to the Makefile package, quality, and dev targets
- keep the change scoped to repository automation that actually installs Composer dependencies

## Why
Issue #1549 asks why the repo would want source checkouts of dependencies instead of dist archives. The current commands did not force source installs, but they also did not state the intended install mode explicitly.

## Impact
CI and Makefile-driven installs now explicitly prefer dist artifacts, which is the expected fast path for dependency installs in automation.

## Validation
- verified all automation Composer install commands now use `--prefer-dist` via `rg -n "composer install" .github/workflows/main.yml Makefile`
- reviewed the exact diff in `.github/workflows/main.yml` and `Makefile`

## Issues
- Closes #1549
