### PR TITLE
fix: correct selected attributes in forms

### DIFF
--- a/tasmoadmin/pages/site_config.php
+++ b/tasmoadmin/pages/site_config.php
@@ -4,6 +4,7 @@ use League\CommonMark\GithubFlavoredMarkdownConverter;
 use Symfony\Component\BrowserKit\HttpBrowser;
 use TasmoAdmin\Helper\CacheCleanupHelper;
 use TasmoAdmin\Helper\GuzzleFactory;
+use TasmoAdmin\Helper\HtmlAttributeHelper;
 use TasmoAdmin\Helper\LoginHelper;
 use TasmoAdmin\Helper\TasmotaHelper;
 use TasmoAdmin\Helper\TasmotaOtaScraper;
@@ -320,49 +321,43 @@ $autoFirmwareChannels = ['stable', 'dev'];
 				<div class="col col-12 col-sm-6">
 					<label for="refreshtime"><?php echo __('CONFIG_REFRESHTIME', 'USER_CONFIG'); ?></label>
 					<select class="form-control form-select" id="refreshtime" name='refreshtime'>
-						<option value='none' <?php echo 'none' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?>>
+						<option value='none' <?php echo HtmlAttributeHelper::selected('none' == $config['refreshtime']); ?>>
 							<?php echo __('CONFIG_REFRESHTIME_NONE', 'USER_CONFIG'); ?>
 						</option>
-						<option value='1' <?php echo '1' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?> >
+						<option value='1' <?php echo HtmlAttributeHelper::selected('1' == $config['refreshtime']); ?> >
 							1 <?php echo __('CONFIG_REFRESHTIME_SECOND', 'USER_CONFIG'); ?>
 						</option>
-						<option value='2' <?php echo '2' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?> >
+						<option value='2' <?php echo HtmlAttributeHelper::selected('2' == $config['refreshtime']); ?> >
 							2 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='3' <?php echo '3' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?> >
+						<option value='3' <?php echo HtmlAttributeHelper::selected('3' == $config['refreshtime']); ?> >
 							3 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='4' <?php echo '4' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?> >
+						<option value='4' <?php echo HtmlAttributeHelper::selected('4' == $config['refreshtime']); ?> >
 							4 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='5' <?php echo '5' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?> >
+						<option value='5' <?php echo HtmlAttributeHelper::selected('5' == $config['refreshtime']); ?> >
 							5 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='8' <?php echo '8' == $config['refreshtime'] ? 'selected=\selected"' : ''; ?> >
+						<option value='8' <?php echo HtmlAttributeHelper::selected('8' == $config['refreshtime']); ?> >
 							8 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='10' <?php echo '10' == $config['refreshtime'] ? 'selected=\selected"'
-                            : ''; ?> >
+						<option value='10' <?php echo HtmlAttributeHelper::selected('10' == $config['refreshtime']); ?> >
 							10 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='15' <?php echo '15' == $config['refreshtime'] ? 'selected=\selected"'
-                            : ''; ?> >
+						<option value='15' <?php echo HtmlAttributeHelper::selected('15' == $config['refreshtime']); ?> >
 							15 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='30' <?php echo '30' == $config['refreshtime'] ? 'selected=\selected"'
-                            : ''; ?> >
+						<option value='30' <?php echo HtmlAttributeHelper::selected('30' == $config['refreshtime']); ?> >
 							30 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='60' <?php echo '60' == $config['refreshtime'] ? 'selected=\selected"'
-                            : ''; ?> >
+						<option value='60' <?php echo HtmlAttributeHelper::selected('60' == $config['refreshtime']); ?> >
 							60 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='120' <?php echo '120' == $config['refreshtime'] ? 'selected=\selected"'
-                            : ''; ?> >
+						<option value='120' <?php echo HtmlAttributeHelper::selected('120' == $config['refreshtime']); ?> >
 							120 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
-						<option value='300' <?php echo '300' == $config['refreshtime'] ? 'selected=\selected"'
-                            : ''; ?> >
+						<option value='300' <?php echo HtmlAttributeHelper::selected('300' == $config['refreshtime']); ?> >
 							300 <?php echo __('CONFIG_REFRESHTIME_SECONDS', 'USER_CONFIG'); ?>
 						</option>
 					</select>

--- a/tasmoadmin/pages/upload_form.php
+++ b/tasmoadmin/pages/upload_form.php
@@ -3,6 +3,7 @@
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use Symfony\Component\BrowserKit\HttpBrowser;
 use TasmoAdmin\Helper\GuzzleFactory;
+use TasmoAdmin\Helper\HtmlAttributeHelper;
 use TasmoAdmin\Helper\TasmotaHelper;
 use TasmoAdmin\Helper\TasmotaOtaScraper;
 
@@ -99,7 +100,7 @@ $fwAssetEsp32 = $Config->read('update_automatic_lang_esp32');
 
 						<?php foreach ($esp8266Releases as $tr) { ?>
 							<option value='<?php echo $tr; ?>'
-								<?php echo $fwAsset === $tr ? 'selected=\selected"' : ''; ?>
+								<?php echo HtmlAttributeHelper::selected($fwAsset === $tr); ?>
 							>
 								<?php echo $tr; ?>
 							</option>
@@ -120,7 +121,7 @@ $fwAssetEsp32 = $Config->read('update_automatic_lang_esp32');
 
 						<?php foreach ($esp32Releases as $tr) { ?>
 							<option value='<?php echo $tr; ?>'
-								<?php echo $fwAssetEsp32 === $tr ? 'selected=\selected"' : ''; ?>
+								<?php echo HtmlAttributeHelper::selected($fwAssetEsp32 === $tr); ?>
 							>
 								<?php echo $tr; ?>
 							</option>

--- a/tasmoadmin/src/Helper/HtmlAttributeHelper.php
+++ b/tasmoadmin/src/Helper/HtmlAttributeHelper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace TasmoAdmin\Helper;
+
+class HtmlAttributeHelper
+{
+    public static function selected(bool $selected): string
+    {
+        return $selected ? 'selected="selected"' : '';
+    }
+}

--- a/tasmoadmin/tests/Helper/HtmlAttributeHelperTest.php
+++ b/tasmoadmin/tests/Helper/HtmlAttributeHelperTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\TasmoAdmin\Helper;
+
+use PHPUnit\Framework\TestCase;
+use TasmoAdmin\Helper\HtmlAttributeHelper;
+
+class HtmlAttributeHelperTest extends TestCase
+{
+    public function testSelectedReturnsHtmlAttributeWhenSelected(): void
+    {
+        self::assertSame('selected="selected"', HtmlAttributeHelper::selected(true));
+    }
+
+    public function testSelectedReturnsEmptyStringWhenNotSelected(): void
+    {
+        self::assertSame('', HtmlAttributeHelper::selected(false));
+    }
+}


### PR DESCRIPTION
## Summary
- fix malformed selected attributes in milestone-touched settings and update forms
- reuse a small helper for selected option rendering
- add a focused PHPUnit test for the helper

## Verification
- ddev exec ./vendor/bin/phpunit tests/Helper/HtmlAttributeHelperTest.php
- ddev exec ./vendor/bin/phpstan analyse src/Helper/HtmlAttributeHelper.php
- full pre-commit gate during commit (php-cs-fixer, phpstan, phpunit)