### PR TITLE
Move backups into the device list and fix sorting

### DIFF
--- a/tasmoadmin/includes/header.php
+++ b/tasmoadmin/includes/header.php
@@ -100,7 +100,6 @@ $viewHelper = $container->get(ViewHelper::class);
 								        'device_config',
 								        'device_action',
 								        'devices_autoscan',
-								        'backup',
 								    ]
 								) ? 'active' : ''; ?>"
 								   href="#"
@@ -122,11 +121,6 @@ $viewHelper = $container->get(ViewHelper::class);
 									>
 										<?php echo __('UPDATE', 'NAVI'); ?>
 									</a>
-
-                                    <a class="dropdown-item nav-link <?php echo 'backup' == $page ? 'active' : ''; ?>"
-                                       href="<?php echo _BASEURL_; ?>backup"
-                                    ><?php echo __('DEVICES_BACKUP', 'NAVI'); ?>
-                                    </a>
 
 									<a class="dropdown-item nav-link <?php echo 'devices_autoscan' == $page ? 'active' : ''; ?>"
 									   href="<?php echo _BASEURL_; ?>devices_autoscan"

--- a/tasmoadmin/index.php
+++ b/tasmoadmin/index.php
@@ -67,6 +67,10 @@ function render_template(Request $request): Response
         $page = $Config->read('homepage');
     }
 
+    if ('backup' === $page) {
+        return new Response('', 302, ['Location' => _BASEURL_.'devices']);
+    }
+
     if (!isset($action)) {
         $action = null;
     }

--- a/tasmoadmin/pages/devices.php
+++ b/tasmoadmin/pages/devices.php
@@ -1,14 +1,41 @@
 <?php
 
+use TasmoAdmin\Backup\BackupHelper;
 use TasmoAdmin\Sonoff;
 
 $Sonoff = $container->get(Sonoff::class);
 $devices = $Sonoff->getDevices();
+
+if (isset($_POST['batch_action']) && 'backup' === $_POST['batch_action'] && isset($_POST['device_ids'])) {
+    $backupHelper = $container->get(BackupHelper::class);
+    $backupResults = $backupHelper->backup($_POST['device_ids']);
+    $backupAction = $backupResults->successful() ? 'success' : 'danger';
+}
 ?>
 <div class='row justify-content-sm-center'>
 	<div class='col col-12 devices-page'>
 
 		<?php if (!empty($devices)) { ?>
+            <?php if (isset($backupResults, $backupAction)) { ?>
+                <div class="devices-panel">
+                    <div class="alert alert-<?php echo $backupAction; ?> fade show mb-0" role="alert">
+                        <div class="col col-12">
+                            <?php echo __('BACKUP_FINISHED', 'BACKUP'); ?> -
+                            <a href="<?php echo _BASEURL_; ?>actions?downloadBackup"><?php echo __('DOWNLOAD_BACKUP', 'BACKUP'); ?></a>
+                            <?php if (!$backupResults->successful()) { ?>
+                                </br>
+                                </br>
+                                <?php echo __('BACKUP_FAILED', 'BACKUP'); ?>
+                                <ul>
+                                    <?php foreach ($backupResults->getFailures() as $failure) { ?>
+                                        <li><?php echo $failure->getDevice()->getName().': '.$failure->getFailureReason(); ?></li>
+                                    <?php } ?>
+                                </ul>
+                            <?php } ?>
+                        </div>
+                    </div>
+                </div>
+            <?php } ?>
 			<div class="devices-panel devices-toolbar">
 				<div class='row g-3 align-items-end devices-toolbar-row'>
 					<div class="col col-12 col-md-auto">
@@ -58,7 +85,9 @@ $devices = $Sonoff->getDevices();
 					</div>
 				</div>
 			</div>
-			<div class="devices-panel devices-table-panel">
+            <form method='post' action='<?php echo _BASEURL_; ?>devices' class='devices-batch-form'>
+                <input type='hidden' name='batch_action' class='batchActionField' value=''>
+                <div class="devices-panel devices-table-panel">
 					<div class='table-responsive double-scroll'>
                         <?php
                         $deviceLinks = true;
@@ -68,33 +97,38 @@ $devices = $Sonoff->getDevices();
 		    include 'elements/devices_table.php';
 		    ?>
 					</div>
-			</div>
-			<div class="devices-panel devices-batch-panel">
-				<div class='row g-3 align-items-end devices-batch-row'>
-					<div class="col col-12 col-lg-auto devices-batch-select-col">
-						<select class='form-select batchActionSelect' aria-label="<?php echo __('PLEASE_SELECT'); ?>">
-							<option value=''><?php echo __('PLEASE_SELECT'); ?></option>
-							<option value='command'><?php echo __('BTN_COMMAND', 'DEVICES'); ?></option>
-							<option value='delete'><?php echo __('DELETE_SELECTED', 'DEVICES'); ?></option>
-						</select>
-					</div>
-					<div class="col col-12 col-lg-auto batchActionCommandWrapper devices-batch-command-col d-none">
-						<input type='text'
-							   name='command'
-							   class='form-control batchActionCommandInput'
-							   placeholder="<?php echo __('CB_COMMAND', 'DEVICES'); ?>"
-						>
-					</div>
-					<div class="col col-12 col-sm-auto devices-batch-submit-col">
-						<button type='button' class='btn btn-primary applyBatchAction w-100' disabled>
-							<?php echo __('PLEASE_SELECT'); ?>
-						</button>
-					</div>
-					<div class="col col-12">
-						<small class="form-text batchActionFeedback d-none"></small>
-					</div>
-				</div>
-			</div>
+                </div>
+                <div class="devices-panel devices-batch-panel">
+                    <div class='row g-3 align-items-end devices-batch-row'>
+                        <div class="col col-12 col-lg-auto devices-batch-select-col">
+                            <select class='form-select batchActionSelect'
+                                    name='batch_action_select'
+                                    aria-label="<?php echo __('PLEASE_SELECT'); ?>"
+                            >
+                                <option value=''><?php echo __('PLEASE_SELECT'); ?></option>
+                                <option value='command'><?php echo __('BTN_COMMAND', 'DEVICES'); ?></option>
+                                <option value='backup'><?php echo __('BACKUP', 'BACKUP'); ?></option>
+                                <option value='delete'><?php echo __('DELETE_SELECTED', 'DEVICES'); ?></option>
+                            </select>
+                        </div>
+                        <div class="col col-12 col-lg-auto batchActionCommandWrapper devices-batch-command-col d-none">
+                            <input type='text'
+                                   name='command'
+                                   class='form-control batchActionCommandInput'
+                                   placeholder="<?php echo __('CB_COMMAND', 'DEVICES'); ?>"
+                            >
+                        </div>
+                        <div class="col col-12 col-sm-auto devices-batch-submit-col">
+                            <button type='button' class='btn btn-primary applyBatchAction w-100' disabled>
+                                <?php echo __('PLEASE_SELECT'); ?>
+                            </button>
+                        </div>
+                        <div class="col col-12">
+                            <small class="form-text batchActionFeedback d-none"></small>
+                        </div>
+                    </div>
+                </div>
+            </form>
 		<?php } else { ?>
 			<div class="devices-panel devices-empty-state text-center">
 				<div class='devices-empty-copy'>

--- a/tasmoadmin/pages/elements/devices_table.php
+++ b/tasmoadmin/pages/elements/devices_table.php
@@ -42,36 +42,36 @@ if (isset($deviceLinks) && $deviceLinks && !isset($deviceLinkActionText)) {
             ></i>
         </th>
         <th data-column-id='version' data-column-label='<?php echo __('TABLE_HEAD_VERSION', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col><?php echo __('TABLE_HEAD_VERSION', 'DEVICES'); ?></th>
-        <th data-column-id='runtime' data-column-label='<?php echo __('TABLE_HEAD_RUNTIME', 'DEVICES'); ?>' data-column-toggle='true'><?php echo __('TABLE_HEAD_RUNTIME', 'DEVICES'); ?></th>
-        <th data-column-id='energyPower' data-column-label='<?php echo __('TABLE_HEAD_ENERGY', 'DEVICES'); ?>' data-column-toggle='true' class='energyPower hidden'><?php echo __(
+        <th data-column-id='runtime' data-column-label='<?php echo __('TABLE_HEAD_RUNTIME', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col><?php echo __('TABLE_HEAD_RUNTIME', 'DEVICES'); ?></th>
+        <th data-column-id='energyPower' data-column-label='<?php echo __('TABLE_HEAD_ENERGY', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='energyPower hidden'><?php echo __(
             'TABLE_HEAD_ENERGY',
             'DEVICES'
         ); ?></th>
-        <th data-column-id='temp' data-column-label='<?php echo __('TABLE_HEAD_TEMP', 'DEVICES'); ?>' data-column-toggle='true' class='temp hidden'><?php echo __('TABLE_HEAD_TEMP', 'DEVICES'); ?></th>
-        <th data-column-id='humidity' data-column-label='<?php echo __('TABLE_HEAD_HUMIDITY', 'DEVICES'); ?>' data-column-toggle='true' class='humidity hidden'><?php echo __(
+        <th data-column-id='temp' data-column-label='<?php echo __('TABLE_HEAD_TEMP', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='temp hidden'><?php echo __('TABLE_HEAD_TEMP', 'DEVICES'); ?></th>
+        <th data-column-id='humidity' data-column-label='<?php echo __('TABLE_HEAD_HUMIDITY', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='humidity hidden'><?php echo __(
             'TABLE_HEAD_HUMIDITY',
             'DEVICES'
         ); ?></th>
-        <th data-column-id='illuminance' data-column-label='<?php echo __('TABLE_HEAD_ILLUMINANCE', 'DEVICES'); ?>' data-column-toggle='true' class='illuminance hidden'><?php echo __(
+        <th data-column-id='illuminance' data-column-label='<?php echo __('TABLE_HEAD_ILLUMINANCE', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='illuminance hidden'><?php echo __(
             'TABLE_HEAD_ILLUMINANCE',
             'DEVICES'
         ); ?></th>
-        <th data-column-id='hostname' data-column-label='<?php echo __('HOSTNAME', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('HOSTNAME', 'DEVICES'); ?></th>
-        <th data-column-id='mac' data-column-label='<?php echo __('MAC', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('MAC', 'DEVICES'); ?></th>
-        <th data-column-id='mqtt' data-column-label='<?php echo __('MQTT', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('MQTT', 'DEVICES'); ?></th>
-        <th data-column-id='idx' data-column-label='<?php echo __('TABLE_HEAD_IDX', 'DEVICES'); ?>' data-column-toggle='true' class='more idx hidden'><?php echo __(
+        <th data-column-id='hostname' data-column-label='<?php echo __('HOSTNAME', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('HOSTNAME', 'DEVICES'); ?></th>
+        <th data-column-id='mac' data-column-label='<?php echo __('MAC', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('MAC', 'DEVICES'); ?></th>
+        <th data-column-id='mqtt' data-column-label='<?php echo __('MQTT', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('MQTT', 'DEVICES'); ?></th>
+        <th data-column-id='idx' data-column-label='<?php echo __('TABLE_HEAD_IDX', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more idx hidden'><?php echo __(
             'TABLE_HEAD_IDX',
             'DEVICES'
         ); ?></th>
-        <th data-column-id='poweronstate' data-column-label='<?php echo __('POWERONSTATE', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('POWERONSTATE', 'DEVICES'); ?></th>
-        <th data-column-id='ledstate' data-column-label='<?php echo __('LEDSTATE', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('LEDSTATE', 'DEVICES'); ?></th>
-        <th data-column-id='savedata' data-column-label='<?php echo __('SAVEDATA', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('SAVEDATA', 'DEVICES'); ?></th>
-        <th data-column-id='sleep' data-column-label='<?php echo __('SLEEP', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('SLEEP', 'DEVICES'); ?></th>
-        <th data-column-id='bootcount' data-column-label='<?php echo __('BOOTCOUNT', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('BOOTCOUNT', 'DEVICES'); ?></th>
-        <th data-column-id='savecount' data-column-label='<?php echo __('SAVECOUNT', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('SAVECOUNT', 'DEVICES'); ?></th>
-        <th data-column-id='log' data-column-label='<?php echo __('LOGSTATES', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('LOGSTATES', 'DEVICES'); ?></th>
-        <th data-column-id='wificonfig' data-column-label='<?php echo __('WIFICONFIG', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('WIFICONFIG', 'DEVICES'); ?></th>
-        <th data-column-id='vcc' data-column-label='<?php echo __('VCC', 'DEVICES'); ?>' data-column-toggle='true' class='more'><?php echo __('VCC', 'DEVICES'); ?></th>
+        <th data-column-id='poweronstate' data-column-label='<?php echo __('POWERONSTATE', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('POWERONSTATE', 'DEVICES'); ?></th>
+        <th data-column-id='ledstate' data-column-label='<?php echo __('LEDSTATE', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('LEDSTATE', 'DEVICES'); ?></th>
+        <th data-column-id='savedata' data-column-label='<?php echo __('SAVEDATA', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('SAVEDATA', 'DEVICES'); ?></th>
+        <th data-column-id='sleep' data-column-label='<?php echo __('SLEEP', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('SLEEP', 'DEVICES'); ?></th>
+        <th data-column-id='bootcount' data-column-label='<?php echo __('BOOTCOUNT', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('BOOTCOUNT', 'DEVICES'); ?></th>
+        <th data-column-id='savecount' data-column-label='<?php echo __('SAVECOUNT', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('SAVECOUNT', 'DEVICES'); ?></th>
+        <th data-column-id='log' data-column-label='<?php echo __('LOGSTATES', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('LOGSTATES', 'DEVICES'); ?></th>
+        <th data-column-id='wificonfig' data-column-label='<?php echo __('WIFICONFIG', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('WIFICONFIG', 'DEVICES'); ?></th>
+        <th data-column-id='vcc' data-column-label='<?php echo __('VCC', 'DEVICES'); ?>' data-column-toggle='true' data-tablesaw-sortable-col class='more'><?php echo __('VCC', 'DEVICES'); ?></th>
 
         <th data-column-id='actions' class='link text-sm-right'>
             <a href='<?php echo _BASEURL_; ?>device_action/add'>

--- a/tasmoadmin/resources/js/device_batch_actions.js
+++ b/tasmoadmin/resources/js/device_batch_actions.js
@@ -15,6 +15,14 @@ function getBatchActionConfig(action) {
     };
   }
 
+  if (action === "backup") {
+    return {
+      action,
+      requiresCommand: false,
+      submitLabelKey: "BTN_START_BACKUP",
+    };
+  }
+
   return null;
 }
 
@@ -40,7 +48,12 @@ function validateBatchAction({
   return null;
 }
 
+function shouldSubmitBatchForm(action = "") {
+  return action === "backup";
+}
+
 module.exports = {
   getBatchActionConfig,
+  shouldSubmitBatchForm,
   validateBatchAction,
 };

--- a/tasmoadmin/resources/js/devices.js
+++ b/tasmoadmin/resources/js/devices.js
@@ -17,7 +17,8 @@ import { getSortableIpCellValue } from "./ip_sort";
 import statusHelpers from "./status_helpers";
 import toggleConfirmation from "./toggle_confirmation";
 
-const { getRuntimeInfo } = statusHelpers;
+const { extractFirstNumericValue, getRuntimeInfo, getSortableVersionValue } =
+  statusHelpers;
 const {
   confirmAction,
   createTouchConfirmController,
@@ -29,13 +30,33 @@ const {
   parseHiddenColumns,
   serializeHiddenColumns,
 } = deviceListPreferences;
-const { getBatchActionConfig, validateBatchAction } = batchActions;
+const { getBatchActionConfig, shouldSubmitBatchForm, validateBatchAction } =
+  batchActions;
 const refreshtime = getRefreshTime();
 
 let ignoreProtectionsTimer;
 let hiddenDeviceColumns = new Set();
 onI18nReady(function () {
   initIpSorting();
+  initCellDataSorting("rssi", ".rssi span", "data-sort-number", true);
+  initCellDataSorting("version", ".version span", "data-sort-text");
+  initCellDataSorting("runtime", ".runtime span", "data-runtime-seconds", true);
+  initCellDataSorting(
+    "energyPower",
+    ".energyPower span",
+    "data-sort-number",
+    true,
+  );
+  initCellDataSorting("temp", ".temp span", "data-sort-number", true);
+  initCellDataSorting("humidity", ".humidity span", "data-sort-number", true);
+  initCellDataSorting(
+    "illuminance",
+    ".illuminance span",
+    "data-sort-number",
+    true,
+  );
+  initCellDataSorting("sleep", ".sleep span", "data-sort-number", true);
+  initCellDataSorting("vcc", ".vcc span", "data-sort-number", true);
   deviceTools();
   initDeviceListPreferences();
 
@@ -108,17 +129,70 @@ function initIpSorting() {
 
       const textA = (a.cell || "").toLowerCase();
       const textB = (b.cell || "").toLowerCase();
-      if (textA === textB) {
-        return 0;
-      }
-
-      if (ascending) {
-        return textA > textB ? 1 : -1;
-      }
-
-      return textA < textB ? 1 : -1;
+      return compareTextValues(textA, textB, ascending);
     };
   });
+}
+
+function compareTextValues(textA, textB, ascending) {
+  if (textA === textB) {
+    return 0;
+  }
+
+  if (ascending) {
+    return textA > textB ? 1 : -1;
+  }
+
+  return textA < textB ? 1 : -1;
+}
+
+function initCellDataSorting(
+  columnId,
+  selector,
+  attributeName,
+  numeric = false,
+) {
+  const header = $(`#device-list thead th[data-column-id='${columnId}']`);
+  if (header.length === 0) {
+    return;
+  }
+
+  header.data("tablesaw-sort", function (ascending) {
+    return function (a, b) {
+      const rawValueA =
+        a.element?.querySelector?.(selector)?.getAttribute?.(attributeName) ??
+        "";
+      const rawValueB =
+        b.element?.querySelector?.(selector)?.getAttribute?.(attributeName) ??
+        "";
+
+      if (numeric) {
+        const valueA = Number.parseFloat(rawValueA);
+        const valueB = Number.parseFloat(rawValueB);
+
+        if (!Number.isNaN(valueA) && !Number.isNaN(valueB)) {
+          return ascending ? valueA - valueB : valueB - valueA;
+        }
+      } else if (rawValueA !== "" && rawValueB !== "") {
+        return compareTextValues(rawValueA, rawValueB, ascending);
+      }
+
+      const textA = (a.cell || "").toLowerCase();
+      const textB = (b.cell || "").toLowerCase();
+      return compareTextValues(textA, textB, ascending);
+    };
+  });
+}
+
+function setSortAttribute(row, selector, attributeName, value) {
+  const cell = $(row).find(selector);
+
+  if (value === null || value === undefined || value === "") {
+    cell.removeAttr(attributeName);
+    return;
+  }
+
+  cell.attr(attributeName, value);
 }
 
 function resizeDeviceListScroller() {
@@ -236,6 +310,7 @@ function initCommandHelper() {
     if ($(this).val() !== "command") {
       $(".batchActionCommandInput").val("");
     }
+    $(".batchActionField").val("");
     resetBatchActionFeedback();
     updateBatchActionUi();
   });
@@ -284,6 +359,21 @@ function initCommandHelper() {
       return false;
     }
 
+    if (shouldSubmitBatchForm(action)) {
+      $(".batchActionField").val("backup");
+      const form = $(this).closest("form").get(0);
+
+      if (form) {
+        if (typeof form.requestSubmit === "function") {
+          form.requestSubmit();
+        } else {
+          form.submit();
+        }
+      }
+
+      return false;
+    }
+
     if (action === "delete") {
       if (!window.confirm(`${$.i18n("DELETE_SELECTED")}?`)) {
         return false;
@@ -297,6 +387,7 @@ function initCommandHelper() {
       return false;
     }
 
+    $(".batchActionField").val("");
     showBatchActionFeedback($.i18n("SUCCESS_COMMAND_SEND"), "text-success");
 
     $.each(selectedDevices, function (idx, device_id) {
@@ -315,6 +406,8 @@ function initCommandHelper() {
         );
       });
     });
+
+    return false;
   });
 
   updateBatchActionUi();
@@ -746,6 +839,7 @@ function updateRow(row, data, device_status) {
     $(row)
       .find(".rssi span")
       .html(rssi + "%")
+      .attr("data-sort-number", rssi)
       .attr("data-bs-title", ssid)
       .attr("data-bs-toggle", "tooltip");
 
@@ -763,6 +857,7 @@ function updateRow(row, data, device_status) {
     $(row)
       .find(".rssi span")
       .html("-")
+      .removeAttr("data-sort-number")
       .removeAttr("data-bs-title")
       .removeAttr("data-bs-toggle");
   }
@@ -770,28 +865,60 @@ function updateRow(row, data, device_status) {
   let energyPower = getEnergyPower(data, " / ");
   if (energyPower !== "") {
     $(row).find(".energyPower span").html(energyPower);
+    setSortAttribute(
+      row,
+      ".energyPower span",
+      "data-sort-number",
+      extractFirstNumericValue(energyPower),
+    );
     $("#device-list .energyPower").removeClass("hidden");
+  } else {
+    setSortAttribute(row, ".energyPower span", "data-sort-number", null);
   }
 
   let temp = getTemp(data);
 
   if (temp !== "") {
     $(row).find(".temp span").html(temp);
+    setSortAttribute(
+      row,
+      ".temp span",
+      "data-sort-number",
+      extractFirstNumericValue(temp),
+    );
     $("#device-list .temp").removeClass("hidden");
+  } else {
+    setSortAttribute(row, ".temp span", "data-sort-number", null);
   }
 
   let humidity = getHumidity(data);
 
   if (humidity !== "") {
     $(row).find(".humidity span").html(humidity);
+    setSortAttribute(
+      row,
+      ".humidity span",
+      "data-sort-number",
+      extractFirstNumericValue(humidity),
+    );
     $("#device-list .humidity").removeClass("hidden");
+  } else {
+    setSortAttribute(row, ".humidity span", "data-sort-number", null);
   }
 
   let illuminance = getIlluminance(data);
 
   if (illuminance !== "") {
     $(row).find(".illuminance span").html(illuminance);
+    setSortAttribute(
+      row,
+      ".illuminance span",
+      "data-sort-number",
+      extractFirstNumericValue(illuminance),
+    );
     $("#device-list .illuminance").removeClass("hidden");
+  } else {
+    setSortAttribute(row, ".illuminance span", "data-sort-number", null);
   }
 
   let pressure = getPressure(data);
@@ -828,7 +955,14 @@ function updateRow(row, data, device_status) {
     $("#device-list .idx").removeClass("hidden").show();
   }
 
-  $(row).find(".version span").html(data.StatusFWR.Version);
+  const version = data.StatusFWR.Version ?? "?";
+  $(row).find(".version span").html(version);
+  setSortAttribute(
+    row,
+    ".version span",
+    "data-sort-text",
+    getSortableVersionValue(version),
+  );
 
   if ($(row).hasClass("toggled")) {
     $(row).removeClass("toggled");
@@ -910,6 +1044,7 @@ function updateRow(row, data, device_status) {
     $(row)
       .find(".runtime span")
       .html(runtime.text)
+      .attr("data-runtime-seconds", runtime.sortValue ?? "")
       .attr(
         "data-bs-title",
         runtime.startupDateTime.toLocaleString(locale, { hour12: false }),
@@ -930,6 +1065,7 @@ function updateRow(row, data, device_status) {
     $(row)
       .find(".runtime span")
       .html(runtime.text)
+      .attr("data-runtime-seconds", runtime.sortValue ?? "")
       .removeAttr("data-bs-title")
       .removeAttr("data-bs-toggle");
   }
@@ -979,6 +1115,14 @@ function updateRow(row, data, device_status) {
       .html(
         data.StatusPRM.Sleep !== undefined ? data.StatusPRM.Sleep + "ms" : "?",
       );
+    setSortAttribute(
+      row,
+      ".sleep span",
+      "data-sort-number",
+      data.StatusPRM.Sleep ?? null,
+    );
+  } else {
+    setSortAttribute(row, ".sleep span", "data-sort-number", null);
   }
 
   $(row)
@@ -1016,6 +1160,12 @@ function updateRow(row, data, device_status) {
   $(row)
     .find(".vcc span")
     .html(data.StatusSTS.Vcc !== undefined ? data.StatusSTS.Vcc + "V" : "?");
+  setSortAttribute(
+    row,
+    ".vcc span",
+    "data-sort-number",
+    data.StatusSTS.Vcc ?? null,
+  );
 
   let device_hostname = sonoff.parseDeviceHostname(data);
   if (device_hostname !== false) {

--- a/tasmoadmin/resources/js/status_helpers.js
+++ b/tasmoadmin/resources/js/status_helpers.js
@@ -33,6 +33,71 @@ function normalizeStatusData(data = {}) {
   return normalized;
 }
 
+function parseUptimeToSeconds(uptime) {
+  if (typeof uptime !== "string") {
+    return null;
+  }
+
+  const normalizedUptime = uptime.trim();
+  const match = normalizedUptime.match(
+    /^(?:(?<days>\d+)T)?(?<hours>\d{1,2}):(?<minutes>\d{2}):(?<seconds>\d{2})$/,
+  );
+
+  if (!match || !match.groups) {
+    return null;
+  }
+
+  const days = Number.parseInt(match.groups.days ?? "0", 10);
+  const hours = Number.parseInt(match.groups.hours, 10);
+  const minutes = Number.parseInt(match.groups.minutes, 10);
+  const seconds = Number.parseInt(match.groups.seconds, 10);
+
+  if (
+    Number.isNaN(days) ||
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    Number.isNaN(seconds)
+  ) {
+    return null;
+  }
+
+  return days * 24 * 3600 + hours * 3600 + minutes * 60 + seconds;
+}
+
+function extractFirstNumericValue(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ");
+  const match = normalizedValue.match(/[-+]?\d*\.?\d+/);
+
+  if (match === null) {
+    return null;
+  }
+
+  const parsedValue = Number.parseFloat(match[0]);
+  return Number.isNaN(parsedValue) ? null : parsedValue;
+}
+
+function getSortableVersionValue(version) {
+  if (typeof version !== "string") {
+    return null;
+  }
+
+  const match = version.match(/(\d+(?:\.\d+)+)/);
+  if (match === null) {
+    return null;
+  }
+
+  return match[1]
+    .split(".")
+    .map((part) => part.padStart(6, "0"))
+    .join(".");
+}
+
 function getRuntimeInfo(data, labels, now = new Date()) {
   const normalized = ensureStatusSections(data);
   const startup =
@@ -44,7 +109,7 @@ function getRuntimeInfo(data, labels, now = new Date()) {
     const startupDateTime = new Date(`${startup}Z`);
 
     if (!Number.isNaN(startupDateTime.getTime())) {
-      const secNum = (now - startupDateTime) / 1000;
+      const secNum = Math.max(0, Math.floor((now - startupDateTime) / 1000));
       const days = Math.floor(secNum / (3600 * 24));
       const hours = Math.floor((secNum - days * (3600 * 24)) / 3600);
       const minutes = Math.floor(
@@ -70,13 +135,18 @@ function getRuntimeInfo(data, labels, now = new Date()) {
 
       return {
         text,
+        sortValue: secNum,
         startupDateTime,
       };
     }
   }
 
+  const fallbackText =
+    normalized.StatusSTS.Uptime ?? normalized.StatusPRM.Uptime ?? "?";
+
   return {
-    text: normalized.StatusSTS.Uptime ?? normalized.StatusPRM.Uptime ?? "?",
+    text: fallbackText,
+    sortValue: parseUptimeToSeconds(fallbackText),
     startupDateTime: null,
   };
 }
@@ -99,7 +169,10 @@ function getIlluminance(data, joinString = "<br/>") {
 }
 
 module.exports = {
+  extractFirstNumericValue,
+  getSortableVersionValue,
   normalizeStatusData,
   getRuntimeInfo,
+  parseUptimeToSeconds,
   getIlluminance,
 };

--- a/tasmoadmin/resources/scss/_style.scss
+++ b/tasmoadmin/resources/scss/_style.scss
@@ -391,7 +391,7 @@ body {
 }
 
 .devices-page .devices-table-panel {
-  padding: 0.9rem 1rem 1rem;
+  padding: 1rem;
 }
 
 .devices-page .devices-batch-panel {
@@ -403,7 +403,7 @@ body {
 }
 
 .devices-page .devices-table-panel .doubleScroll-scroll-wrapper {
-  margin-bottom: 0.65rem;
+  margin-bottom: 0;
 }
 
 .devices-page #device-list {

--- a/tasmoadmin/tests/Page/DevicesPageBackupWorkflowTest.php
+++ b/tasmoadmin/tests/Page/DevicesPageBackupWorkflowTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TasmoAdmin\Page;
+
+use PHPUnit\Framework\TestCase;
+use TasmoAdmin\Backup\BackupHelper;
+use TasmoAdmin\Backup\BackupResult;
+use TasmoAdmin\Backup\BackupResults;
+use TasmoAdmin\Device;
+use TasmoAdmin\Sonoff;
+
+class DevicesPageBackupWorkflowTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $_POST = [];
+    }
+
+    public function testDevicesPageRendersBackupAsBatchAction(): void
+    {
+        $devices = [$this->createDevice(1, 'Desk Lamp')];
+        $output = $this->renderDevicesPage($devices);
+
+        self::assertStringContainsString("<option value='backup'>", $output);
+        self::assertStringContainsString('batchActionSelect', $output);
+    }
+
+    public function testDevicesPageShowsInlineBackupResultAndFailures(): void
+    {
+        $_POST = [
+            'batch_action' => 'backup',
+            'device_ids' => ['1', '2'],
+        ];
+
+        $devices = [
+            $this->createDevice(1, 'Desk Lamp'),
+            $this->createDevice(2, 'Shelf Plug'),
+        ];
+        $results = new BackupResults([
+            new BackupResult($devices[0], true),
+            new BackupResult($devices[1], false, 'Connection timed out'),
+        ]);
+
+        $output = $this->renderDevicesPage($devices, $results);
+
+        self::assertStringContainsString('BACKUP_BACKUP_FINISHED:', $output);
+        self::assertStringContainsString('/actions?downloadBackup', $output);
+        self::assertStringContainsString('BACKUP_BACKUP_FAILED:', $output);
+        self::assertStringContainsString('Shelf Plug: Connection timed out', $output);
+    }
+
+    private function renderDevicesPage(array $devices, ?BackupResults $backupResults = null): string
+    {
+        if (!defined('_BASEURL_')) {
+            define('_BASEURL_', '/');
+        }
+        if (!defined('_RESOURCESURL_')) {
+            define('_RESOURCESURL_', '/resources/');
+        }
+
+        $Config = new class {
+            public function read(string $key): string
+            {
+                return match ($key) {
+                    'show_search' => '1',
+                    default => '',
+                };
+            }
+        };
+
+        $urlHelper = new class {
+            public function js(string $path): string
+            {
+                return '/js/'.$path.'.js';
+            }
+        };
+
+        $container = new class($devices, $backupResults) {
+            public function __construct(private array $devices, private ?BackupResults $backupResults) {}
+
+            public function get(string $class): object
+            {
+                return match ($class) {
+                    Sonoff::class => new class($this->devices) {
+                        public function __construct(private array $devices) {}
+
+                        public function getDevices(): array
+                        {
+                            return $this->devices;
+                        }
+                    },
+                    BackupHelper::class => new class($this->backupResults) {
+                        public function __construct(private ?BackupResults $backupResults) {}
+
+                        public function backup(array $deviceIds): BackupResults
+                        {
+                            return $this->backupResults ?? new BackupResults([]);
+                        }
+                    },
+                    default => throw new \InvalidArgumentException('Unexpected class '.$class),
+                };
+            }
+        };
+
+        ob_start();
+
+        try {
+            include __DIR__.'/../../pages/devices.php';
+
+            return (string) ob_get_clean();
+        } catch (\Throwable $exception) {
+            ob_end_clean();
+
+            throw $exception;
+        }
+    }
+
+    private function createDevice(int $id, string $name): Device
+    {
+        return new Device($id, [$name], '192.168.1.'.$id, '', '');
+    }
+}

--- a/tasmoadmin/tests/Page/DevicesTableSortableColumnsTest.php
+++ b/tasmoadmin/tests/Page/DevicesTableSortableColumnsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TasmoAdmin\Page;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use TasmoAdmin\Device;
+
+class DevicesTableSortableColumnsTest extends TestCase
+{
+    #[DataProvider('sortableColumnProvider')]
+    public function testDevicesTableMarksExpectedColumnsAsSortable(string $columnId): void
+    {
+        if (!defined('_BASEURL_')) {
+            define('_BASEURL_', '/');
+        }
+        if (!defined('_RESOURCESURL_')) {
+            define('_RESOURCESURL_', '/resources/');
+        }
+
+        $devices = [
+            new Device(1, ['Desk Lamp'], '192.168.1.10', '', ''),
+        ];
+        $deviceLinks = false;
+        $deviceLinksHideClass = '';
+
+        ob_start();
+
+        include __DIR__.'/../../pages/elements/devices_table.php';
+        $output = ob_get_clean();
+
+        self::assertIsString($output);
+        self::assertMatchesRegularExpression(
+            sprintf(
+                "/<th[^>]*data-column-id='%s'[^>]*data-tablesaw-sortable-col/s",
+                preg_quote($columnId, '/')
+            ),
+            $output
+        );
+    }
+
+    public static function sortableColumnProvider(): array
+    {
+        return [
+            ['id'],
+            ['position'],
+            ['name'],
+            ['ip'],
+            ['rssi'],
+            ['version'],
+            ['runtime'],
+            ['energyPower'],
+            ['temp'],
+            ['humidity'],
+            ['illuminance'],
+            ['hostname'],
+            ['mac'],
+            ['mqtt'],
+            ['idx'],
+            ['poweronstate'],
+            ['ledstate'],
+            ['savedata'],
+            ['sleep'],
+            ['bootcount'],
+            ['savecount'],
+            ['log'],
+            ['wificonfig'],
+            ['vcc'],
+        ];
+    }
+}

--- a/tasmoadmin/tests/Page/HeaderDevicesNavigationTest.php
+++ b/tasmoadmin/tests/Page/HeaderDevicesNavigationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TasmoAdmin\Page;
+
+use PHPUnit\Framework\TestCase;
+use TasmoAdmin\Helper\UrlHelper;
+use TasmoAdmin\Helper\ViewHelper;
+
+class HeaderDevicesNavigationTest extends TestCase
+{
+    public function testHeaderDoesNotRenderStandaloneBackupEntryInDevicesMenu(): void
+    {
+        if (!defined('_BASEURL_')) {
+            define('_BASEURL_', '/');
+        }
+        if (!defined('_RESOURCESURL_')) {
+            define('_RESOURCESURL_', '/resources/');
+        }
+        if (!defined('_RESOURCESDIR_')) {
+            define('_RESOURCESDIR_', dirname(__DIR__, 2).'/resources/');
+        }
+
+        $lang = 'en';
+        $page = 'devices';
+        $loggedin = true;
+        $docker = false;
+
+        $Config = new class {
+            public function read(string $key): string
+            {
+                return match ($key) {
+                    'homepage' => 'devices',
+                    'nightmode' => 'disable',
+                    default => '0',
+                };
+            }
+
+            public function getRequestConcurrency(): int
+            {
+                return 4;
+            }
+        };
+
+        $container = new class {
+            public function get(string $class): object
+            {
+                return match ($class) {
+                    UrlHelper::class => new class {
+                        public function js(string $path): string
+                        {
+                            return '/js/'.$path.'.js';
+                        }
+
+                        public function style(string $path): string
+                        {
+                            return '/css/'.$path.'.css';
+                        }
+                    },
+                    ViewHelper::class => new class {
+                        public function getValue(bool $value): string
+                        {
+                            return $value ? 'true' : 'false';
+                        }
+
+                        public function getNightMode(string $hour): string
+                        {
+                            return 'daymode';
+                        }
+                    },
+                    default => throw new \InvalidArgumentException('Unexpected class '.$class),
+                };
+            }
+        };
+
+        ob_start();
+
+        try {
+            include __DIR__.'/../../includes/header.php';
+            $output = (string) ob_get_clean();
+        } catch (\Throwable $exception) {
+            ob_end_clean();
+
+            throw $exception;
+        }
+
+        self::assertStringNotContainsString('NAVI_DEVICES_BACKUP:', $output);
+        self::assertStringContainsString('NAVI_DEVICE_LIST:', $output);
+        self::assertStringContainsString('NAVI_DEVICES_AUTOSCAN:', $output);
+    }
+}

--- a/tasmoadmin/tests/js/device_batch_actions.test.js
+++ b/tasmoadmin/tests/js/device_batch_actions.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
   getBatchActionConfig,
+  shouldSubmitBatchForm,
   validateBatchAction,
 } = require("../../resources/js/device_batch_actions.js");
 
@@ -10,6 +11,14 @@ test("getBatchActionConfig returns command metadata", () => {
     action: "command",
     requiresCommand: true,
     submitLabelKey: "SEND_COMMAND",
+  });
+});
+
+test("getBatchActionConfig returns backup metadata", () => {
+  assert.deepEqual(getBatchActionConfig("backup"), {
+    action: "backup",
+    requiresCommand: false,
+    submitLabelKey: "BTN_START_BACKUP",
   });
 });
 
@@ -60,4 +69,17 @@ test("validateBatchAction accepts valid delete and command actions", () => {
     }),
     null,
   );
+  assert.equal(
+    validateBatchAction({
+      action: "backup",
+      selectedDeviceIds: ["1"],
+    }),
+    null,
+  );
+});
+
+test("only backup submits the batch form", () => {
+  assert.equal(shouldSubmitBatchForm("command"), false);
+  assert.equal(shouldSubmitBatchForm("delete"), false);
+  assert.equal(shouldSubmitBatchForm("backup"), true);
 });

--- a/tasmoadmin/tests/js/status_helpers.test.js
+++ b/tasmoadmin/tests/js/status_helpers.test.js
@@ -3,7 +3,10 @@ const assert = require("node:assert/strict");
 const {
   normalizeStatusData,
   getRuntimeInfo,
+  parseUptimeToSeconds,
+  extractFirstNumericValue,
   getIlluminance,
+  getSortableVersionValue,
 } = require("../../resources/js/status_helpers.js");
 
 test("normalizeStatusData fills missing sections for ethernet payloads", () => {
@@ -38,6 +41,15 @@ test("normalizeStatusData fills missing sections for ethernet payloads", () => {
       second: "s",
     }).text,
     "87T15:29:29",
+  );
+  assert.equal(
+    getRuntimeInfo(data, {
+      day: "d",
+      hour: "h",
+      minute: "m",
+      second: "s",
+    }).sortValue,
+    7572569,
   );
 });
 
@@ -80,4 +92,51 @@ test("getIlluminance extracts illuminance readings from sensor payloads", () => 
     ),
     "40 lx | 125 lx",
   );
+});
+
+test("getRuntimeInfo returns a numeric sort value for startup-derived runtime", () => {
+  const info = getRuntimeInfo(
+    {
+      StatusPRM: {
+        StartupDateTimeUtc: "2026-06-11T10:00:00",
+      },
+    },
+    {
+      day: "d",
+      hour: "h",
+      minute: "m",
+      second: "s",
+    },
+    new Date("2026-06-11T12:03:04Z"),
+  );
+
+  assert.equal(info.text, "2h 3m 4s");
+  assert.equal(info.sortValue, 7384);
+});
+
+test("parseUptimeToSeconds parses Tasmota uptime strings", () => {
+  assert.equal(parseUptimeToSeconds("87T15:29:29"), 7572569);
+  assert.equal(parseUptimeToSeconds("00:47:59"), 2879);
+  assert.equal(parseUptimeToSeconds("?"), null);
+});
+
+test("extractFirstNumericValue reads the first sortable number from formatted values", () => {
+  assert.equal(extractFirstNumericValue("105 W / 0.329 / 0.513 / 12.345 kWh"), 105);
+  assert.equal(extractFirstNumericValue("-4.5°C<br/>12.3°C"), -4.5);
+  assert.equal(extractFirstNumericValue("3.21V"), 3.21);
+  assert.equal(extractFirstNumericValue("?"), null);
+});
+
+test("getSortableVersionValue normalizes version strings for semantic sorting", () => {
+  assert.equal(
+    getSortableVersionValue("14.4.0.1(tasmota32)") >
+      getSortableVersionValue("9.5.0.4(ethernet)"),
+    true,
+  );
+  assert.equal(
+    getSortableVersionValue("14.4.10(tasmota)") >
+      getSortableVersionValue("14.4.2(tasmota)"),
+    true,
+  );
+  assert.equal(getSortableVersionValue("?"), null);
 });


### PR DESCRIPTION
## What changed
- move the backup flow from the separate backup page into the devices batch action dropdown
- redirect `/backup` to `/devices` and remove the old devices navigation entry
- show inline backup results on the devices page
- make the sortable devices columns consistent, including semantic sorting for runtime and other formatted values
- add page and JS regression coverage for the backup flow and sorting behavior

## Why
The backup flow lived on a separate page even though it operates on selected devices, and several device-list columns only sorted by display text. That made the backup path less direct and caused incorrect ordering for formatted values such as runtime.

## Impact
Users can now trigger backups directly from the devices page and get the result without leaving the device list. Device sorting is more predictable for batch operations and troubleshooting because formatted values now sort semantically instead of lexicographically.

## Root cause
The old flow split device selection and backup execution across two pages, while the table relied mostly on default text sorting even for columns whose visible values were formatted strings.

## Validation
- pre-commit php-cs-fixer
- pre-commit phpstan
- pre-commit phpunit
- pre-commit prettier:check
- pre-commit `node --test "tests/js/**/*.test.js"`
- pre-commit `npm run build`
