### PR TITLE
Fix: escape device IP and keywords output in devices table

### DIFF
--- a/tasmoadmin/pages/elements/devices_table.php
+++ b/tasmoadmin/pages/elements/devices_table.php
@@ -88,10 +88,10 @@ if (isset($devices) && !empty($devices)) {
                     data-device_id='<?php echo $device_group->id; ?>'
                     data-device_group='<?php echo count($device_group->names) > 1
                     ? 'multi' : 'single'; ?>'
-                    data-device_ip='<?php echo $device_group->ip; ?>'
+                    data-device_ip='<?php echo htmlspecialchars($device_group->ip, ENT_QUOTES, 'UTF-8'); ?>'
                     data-device_relais='<?php echo $key + 1; ?>'
                     data-device_confirm_toggle='<?php echo $device_group->deviceConfirmToggle ? '1' : '0'; ?>'
-                    data-keywords="<?php echo implode(' ', $device_group->keywords); ?>"
+                    data-keywords="<?php echo htmlspecialchars(implode(' ', $device_group->keywords), ENT_QUOTES, 'UTF-8'); ?>"
                 >
                     <?php if (isset($deviceLinks) && true === $deviceLinks) { ?>
                     <td class='cmd_cb <?php echo $deviceLinksHideClass; ?>'>
@@ -133,7 +133,7 @@ if (isset($devices) && !empty($devices)) {
                     </td>
                     <td data-column-id='ip'>
                         <span class="tablesaw-sort-value"><?php echo sprintf('%u', ip2long($device_group->ip)); ?></span>
-                        <span class="device-ip-text"><?php echo $device_group->ip; ?></span>
+                        <span class="device-ip-text"><?php echo htmlspecialchars($device_group->ip, ENT_QUOTES, 'UTF-8'); ?></span>
                     </td>
                     <td class='status' data-column-id='status'>
                         <label class="form-switch">


### PR DESCRIPTION
The device IP field in the admin panel accepts arbitrary input with no validation. Values were rendered unescaped in the devices table HTML, which could allow stored XSS if a crafted value is written to the field.

This wraps the output with `htmlspecialchars()` in three locations:
- `data-device_ip` attribute in the table row
- `data-keywords` attribute (derived from device data)
- Device IP text display in the table cell

Requires admin-level access or a chained CSRF to store the payload, so this is defense-in-depth hardening rather than a standalone exploit fix.